### PR TITLE
Adds line height transform, Adds description to comment transform

### DIFF
--- a/.changeset/five-melons-move.md
+++ b/.changeset/five-melons-move.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Add lineheight tranform for aligning Figma and CSS behaviour. Add transform to assign Tokens Studio description to Style Dictionary comment.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ to work with Design Tokens that are exported from [Tokens Studio](https://tokens
 - Check and evaluate Math expressions (transitive)
 - Transform dimensions tokens to have `px` as a unit when missing (transitive)
 - Transform letterspacing from `%` to `em`
+- Transform lineheight from `%` to unitless (150% -> 1.5)
 - Transform fontweight from keynames to fontweight numbers (100, 200, 300 ... 900)
 - Transform colors to `rgba()` format
 - Transform typography objects to CSS typography parts
@@ -60,6 +61,7 @@ In your Style-Dictionary config:
         "ts/resolveMath",
         "ts/size/px",
         "ts/size/letterspacing",
+        "ts/size/lineheight",
         "ts/type/fontWeight",
         "ts/color/hexrgba",
         "ts/typography/shorthand",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This package contains custom transforms for [Style-Dictionary](https://amzn.github.io/style-dictionary/#/),
 to work with Design Tokens that are exported from [Tokens Studio](https://tokens.studio/):
 
+- Maps token descriptions to comments
 - Check and evaluate Math expressions (transitive)
 - Transform dimensions tokens to have `px` as a unit when missing (transitive)
 - Transform letterspacing from `%` to `em`
@@ -58,6 +59,7 @@ In your Style-Dictionary config:
     },
     "css": {
       "transforms": [
+        "ts/descriptionToComment",
         "ts/resolveMath",
         "ts/size/px",
         "ts/size/letterspacing",

--- a/index.js
+++ b/index.js
@@ -7,3 +7,4 @@ export { transformLineHeight } from './src/transformLineHeight.js';
 export { transformShadow } from './src/transformShadow.js';
 export { transformTypography } from './src/transformTypography.js';
 export { registerTransforms } from './src/registerTransforms.js';
+export { mapDescriptionToComment } from './src/mapDescriptionToComment.js';

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export { transformDimension } from './src/transformDimension.js';
 export { transformFontWeights } from './src/transformFontWeights.js';
 export { transformHEXRGBa } from './src/transformHEXRGBa.js';
 export { transformLetterSpacing } from './src/transformLetterSpacing.js';
+export { transformLineHeight } from './src/transformLineHeight.js';
 export { transformShadow } from './src/transformShadow.js';
 export { transformTypography } from './src/transformTypography.js';
 export { registerTransforms } from './src/registerTransforms.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "color2k": "^2.0.1",

--- a/src/mapDescriptionToComment.js
+++ b/src/mapDescriptionToComment.js
@@ -5,7 +5,7 @@
  * Helper: Maps the token description to a style dictionary comment attribute - this will be picked up by some Style Dictionary
  * formats and automatically output as code comments
  * @param {DesignTokenWithDescription} token
- * @returns {DesignTokenWithDescription} token
+ * @returns {DesignTokenWithDescription}
  */
 export function mapDescriptionToComment(token) {
   // purposeful mutation of the original object

--- a/src/mapDescriptionToComment.js
+++ b/src/mapDescriptionToComment.js
@@ -8,7 +8,7 @@
  * @returns {DesignTokenWithDescription}
  */
 export function mapDescriptionToComment(token) {
-  // purposeful mutation of the original object
+  // intentional mutation of the original object
   const _t = token;
   _t.comment = _t.description;
   return _t;

--- a/src/mapDescriptionToComment.js
+++ b/src/mapDescriptionToComment.js
@@ -1,0 +1,15 @@
+/**
+ * @typedef {import("./registerTransforms").DesignToken & { description?: string }} DesignTokenWithDescription
+ */
+/**
+ * Helper: Maps the token description to a style dictionary comment attribute - this will be picked up by some Style Dictionary
+ * formats and automatically output as code comments
+ * @param {DesignTokenWithDescription} token
+ * @returns {DesignTokenWithDescription} token
+ */
+export function mapDescriptionToComment(token) {
+  // purposeful mutation of the original object
+  const _t = token;
+  _t.comment = _t.description;
+  return _t;
+}

--- a/src/registerTransforms.js
+++ b/src/registerTransforms.js
@@ -3,6 +3,7 @@ import { transformHEXRGBa } from './transformHEXRGBa.js';
 import { transformShadow } from './transformShadow.js';
 import { transformFontWeights } from './transformFontWeights.js';
 import { transformLetterSpacing } from './transformLetterSpacing.js';
+import { transformLineHeight } from './transformLineHeight.js';
 import { transformTypography } from './transformTypography.js';
 import { checkAndEvaluateMath } from './checkAndEvaluateMath.js';
 
@@ -79,6 +80,14 @@ export async function registerTransforms(sd) {
   });
 
   _sd.registerTransform({
+    name: 'ts/size/lineheight',
+    type: 'value',
+    transitive: true,
+    matcher: token => token.type === 'lineHeights',
+    transformer: token => transformLineHeight(token.value),
+  });
+
+  _sd.registerTransform({
     name: 'ts/typography/shorthand',
     type: 'value',
     transitive: true,
@@ -101,6 +110,7 @@ export async function registerTransforms(sd) {
       'ts/resolveMath',
       'ts/size/px',
       'ts/size/letterspacing',
+      'ts/size/lineheight',
       'ts/type/fontWeight',
       'ts/color/hexrgba',
       'ts/typography/shorthand',

--- a/src/registerTransforms.js
+++ b/src/registerTransforms.js
@@ -6,6 +6,7 @@ import { transformLetterSpacing } from './transformLetterSpacing.js';
 import { transformLineHeight } from './transformLineHeight.js';
 import { transformTypography } from './transformTypography.js';
 import { checkAndEvaluateMath } from './checkAndEvaluateMath.js';
+import { mapDescriptionToComment } from './mapDescriptionToComment.js';
 
 /**
  * @typedef {import('style-dictionary/types/index')} StyleDictionary
@@ -104,9 +105,17 @@ export async function registerTransforms(sd) {
     transformer: token => `${checkAndEvaluateMath(token.value)}`,
   });
 
+  _sd.registerTransform({
+    name: 'ts/descriptionToComment',
+    type: 'attribute',
+    matcher: token => token.description,
+    transformer: token => mapDescriptionToComment(token),
+  });
+
   _sd.registerTransformGroup({
     name: 'tokens-studio',
     transforms: [
+      'ts/descriptionToComment',
       'ts/resolveMath',
       'ts/size/px',
       'ts/size/letterspacing',

--- a/src/transformFontWeights.js
+++ b/src/transformFontWeights.js
@@ -26,7 +26,7 @@ const fontWeightMap = {
 };
 
 /**
- * Helper: Transforms letter spacing % to em
+ * Helper: Transforms fontweight keynames to fontweight numbers (100, 200, 300 ... 900)
  * @param {string} value
  */
 export function transformFontWeights(value) {

--- a/src/transformLineHeight.js
+++ b/src/transformLineHeight.js
@@ -3,12 +3,12 @@
  * @example
  * 150% -> 1.5
  * @param {string} value
- * @returns {string}
+ * @returns {string | number}
  */
 export function transformLineHeight(value) {
   if (value.endsWith('%')) {
     const percentValue = value.slice(0, -1);
-    return `${parseFloat(percentValue) / 100}`;
+    return parseFloat(percentValue) / 100;
   }
   return value;
 }

--- a/src/transformLineHeight.js
+++ b/src/transformLineHeight.js
@@ -1,0 +1,14 @@
+/**
+ * Helper: Transforms line-height % to unit-less decimal value
+ * @example
+ * 150% -> 1.5
+ * @param {string} value
+ * @returns {string}
+ */
+export function transformLineHeight(value) {
+  if (value.endsWith('%')) {
+    const percentValue = value.slice(0, -1);
+    return `${parseFloat(percentValue) / 100}`;
+  }
+  return value;
+}


### PR DESCRIPTION
@six7 @jorenbroekema 
addresses https://github.com/tokens-studio/sd-transforms/issues/11

For this SD json
```json
 "lineHeights": {
    "0": {
      "value": "AUTO",
      "type": "lineHeights",
      "description": "line height description"
    },
    "1": {
      "value": "130%",
      "type": "lineHeights",
      "description": "line height description"
    },
    "2": {
      "value": "120%",
      "type": "lineHeights",
      "description": "line height description"
    }
  },
```

the output is like 

```js
export const lineHeights0 = "AUTO"; // line height description
export const lineHeights1 = 1.3; // line height description
export const lineHeights2 = 1.2; // line height description
```