### PR TITLE
Include missing token types in to/size transform function

### DIFF
--- a/.changeset/angry-squids-tie.md
+++ b/.changeset/angry-squids-tie.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Include missing token types (sizing, borderWidth) in ts/size/px transform matcher.

--- a/src/registerTransforms.js
+++ b/src/registerTransforms.js
@@ -38,7 +38,9 @@ export async function registerTransforms(sd) {
     type: 'value',
     transitive: true,
     matcher: /** @param {DesignToken} token */ token =>
-      ['fontSizes', 'dimension', 'borderRadius', 'spacing'].includes(token.type),
+      ['sizing', 'spacing', 'borderRadius', 'borderWidth', 'fontSizes', 'dimension'].includes(
+        token.type,
+      ),
     transformer: /** @param {DesignToken} token */ token => transformDimension(token.value),
   });
 


### PR DESCRIPTION
The `ts/size/px` transform function is missing specific token types that it should include.

This pull requests adds `sizing` and `borderWidth`. It also sorts the token types list in the same order as what is in the documentation, https://docs.tokens.studio/available-tokens/available-tokens.