### PR TITLE
remove attribute/cti transform as it is not needed nor used

### DIFF
--- a/.changeset/lazy-mangos-buy.md
+++ b/.changeset/lazy-mangos-buy.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': minor
+---
+
+BREAKING: remove attribute/cti transform from tokens-studio transform group, this is redundant. However, users might rely on it, therefore it is a breaking change.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to work with Design Tokens that are exported from [Tokens Studio](https://tokens
 - Transform typography objects to CSS typography parts
 - Transform Tokens Studio shadow objects to CSS shadow format
 - Transform color modifiers from Tokens Studio to color values
-- Registers these transforms, in addition to `attribute/cti`, `name/cti/camelCase` for naming purposes, as a transform group called `tokens-studio`
+- Registers these transforms, in addition to `name/cti/camelCase` for naming purposes, as a transform group called `tokens-studio`
 
 ## Installation
 
@@ -118,7 +118,6 @@ const sd = StyleDictionary.extend({
         'ts/color/modifiers',
         'ts/typography/css/shorthand',
         'ts/shadow/shorthand',
-        'attribute/cti',
         'name/cti/kebab',
       ],
       buildPath: 'build/css/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "color2k": "^2.0.1",

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -137,7 +137,6 @@ export async function registerTransforms(sd: Core) {
       'ts/color/modifiers',
       'ts/typography/css/shorthand',
       'ts/shadow/shorthand',
-      'attribute/cti',
       // by default we go with camel, as having no default will likely give the user
       // errors straight away. This can be overridden by manually passing an array of transforms
       // instead of this transformGroup, or by doing a name conversion in your custom format


### PR DESCRIPTION
This PR removes `attribute/cti` transform as it is not needed nor used. 
See https://github.com/tokens-studio/sd-transforms/issues/33 for more details