### PR TITLE
fix: evaluateAndCheckMath no trailing space for normal values with spaces

### DIFF
--- a/.changeset/early-ghosts-sort.md
+++ b/.changeset/early-ghosts-sort.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Fix checkAndEvaluateMath to deal with regular values with spaces in them like linear-gradient(a, b1 b2, c1 c2).

--- a/src/checkAndEvaluateMath.ts
+++ b/src/checkAndEvaluateMath.ts
@@ -43,7 +43,9 @@ function splitMultiIntoSingleValues(expr: string): string[] {
     let currIndex = 0;
     indexes.forEach(i => {
       const singleValue = tokens.slice(currIndex, i + 1).join(' ');
-      exprArr.push(singleValue);
+      if (singleValue) {
+        exprArr.push(singleValue);
+      }
       currIndex = i + 1;
     });
     return exprArr;

--- a/test/checkAndEvaluateMath.test.ts
+++ b/test/checkAndEvaluateMath.test.ts
@@ -39,5 +39,9 @@ describe('check and evaluate math', () => {
     expect(checkAndEvaluateMath('5px + 4px + 10px 3 * 2px')).to.equal('19px 6px');
     expect(checkAndEvaluateMath('5px 3 * 2px')).to.equal('5px 6px');
     expect(checkAndEvaluateMath('3 * 2px 5px')).to.equal('6px 5px');
+    // smoke test: this value has spaces as well but should be handled normally
+    expect(checkAndEvaluateMath('linear-gradient(90deg, #354752 0%, #0b0d0e 100%)')).to.equal(
+      'linear-gradient(90deg, #354752 0%, #0b0d0e 100%)',
+    );
   });
 });


### PR DESCRIPTION
fixes https://github.com/tokens-studio/sd-transforms/issues/39