### PR TITLE
fix: use resolved/transformed value rather than original in transforms

### DIFF
--- a/.changeset/wild-cougars-kneel.md
+++ b/.changeset/wild-cougars-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Do not use original value for transforms, use transformed value instead.

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -6,9 +6,9 @@ import { transformFontWeights } from '../transformFontWeights.js';
  * If you'd like to output all typography values, you'd rather need to return the typography properties itself
  */
 export function transformTypographyForCSS(
-  value: Record<string, string> | undefined,
+  value: Record<string, string> | undefined | string,
 ): string | undefined {
-  if (value === undefined) {
+  if (value === undefined || typeof value !== 'object') {
     return value;
   }
   const { fontWeight, fontSize, lineHeight, fontFamily } = value;

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -63,9 +63,9 @@ export async function registerTransforms(sd: Core) {
     transitive: true,
     matcher: token => ['boxShadow'].includes(token.type),
     transformer: token =>
-      Array.isArray(token.original.value)
-        ? token.original.value.map(single => transformShadow(single)).join(', ')
-        : transformShadow(token.original.value),
+      Array.isArray(token.value)
+        ? token.value.map(single => transformShadow(single)).join(', ')
+        : transformShadow(token.value),
   });
 
   _sd.registerTransform({
@@ -97,7 +97,7 @@ export async function registerTransforms(sd: Core) {
     type: 'value',
     transitive: true,
     matcher: token => token.type === 'typography',
-    transformer: token => transformTypographyForCSS(token.original.value),
+    transformer: token => transformTypographyForCSS(token.value),
   });
 
   _sd.registerTransform({
@@ -105,7 +105,7 @@ export async function registerTransforms(sd: Core) {
     type: 'value',
     transitive: true,
     matcher: token => token.type === 'typography',
-    transformer: token => transformTypographyForCompose(token.original.value),
+    transformer: token => transformTypographyForCompose(token.value),
   });
 
   _sd.registerTransform({

--- a/test/integration/tokens/typography.tokens.json
+++ b/test/integration/tokens/typography.tokens.json
@@ -1,0 +1,28 @@
+{
+  "before": {
+    "value": "{font.heading.xxl}",
+    "type": "typography"
+  },
+  "font": {
+    "heading": {
+      "xxl": {
+        "value": {
+          "fontFamily": "Aria Sans",
+          "fontWeight": "700",
+          "lineHeight": "1",
+          "fontSize": "36px",
+          "letterSpacing": "1",
+          "paragraphSpacing": "1",
+          "paragraphIndent": "1",
+          "textCase": "none",
+          "textDecoration": "none"
+        },
+        "type": "typography"
+      }
+    }
+  },
+  "after": {
+    "value": "{font.heading.xxl}",
+    "type": "typography"
+  }
+}

--- a/test/integration/typography-references.test.ts
+++ b/test/integration/typography-references.test.ts
@@ -1,0 +1,64 @@
+import { expect } from '@esm-bundle/chai';
+import StyleDictionary from 'style-dictionary';
+import { promises } from 'fs';
+import path from 'path';
+import { registerTransforms } from '../../src/registerTransforms.js';
+
+const outputDir = 'test/integration/tokens/';
+const outputFileName = 'vars.css';
+const outputFilePath = path.resolve(outputDir, outputFileName);
+
+const cfg = {
+  source: ['test/integration/tokens/typography.tokens.json'],
+  platforms: {
+    css: {
+      transformGroup: 'tokens-studio',
+      prefix: 'sd',
+      buildPath: outputDir,
+      files: [
+        {
+          destination: outputFileName,
+          format: 'css/variables',
+        },
+      ],
+    },
+  },
+};
+
+let dict: StyleDictionary.Core | undefined;
+
+describe('typography references', () => {
+  function cleanup() {
+    if (dict) {
+      dict.cleanAllPlatforms();
+    }
+    delete StyleDictionary.transformGroup['tokens-studio'];
+    Object.keys(StyleDictionary.transform).forEach(transform => {
+      if (transform.startsWith('ts/')) {
+        delete StyleDictionary.transform[transform];
+      }
+    });
+  }
+
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('supports typography objects when referenced by another token', async () => {
+    registerTransforms(StyleDictionary);
+    dict = StyleDictionary.extend(cfg);
+    dict.buildAllPlatforms();
+    const file = await promises.readFile(outputFilePath, 'utf-8');
+    expect(file).to.include(
+      `:root {
+  --sdBefore: 700 36/1 Aria Sans;
+  --sdFontHeadingXxl: 700 36px/1 Aria Sans;
+  --sdAfter: 700 36/1 Aria Sans;
+}`,
+    );
+  });
+});


### PR DESCRIPTION
@six7  can you review this one? It seemed like the token `original.value` was a conscious choice, but I can't really figure out why you would want the untransformed/unresolved value to transform, this won't work for reference values?

Let me know if there's other cases I should test before committing to this change.

fixes https://github.com/tokens-studio/sd-transforms/issues/70