### PR TITLE
fix: add opacity percentage handling

### DIFF
--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -10,6 +10,7 @@ import { transformTypographyForCompose } from './compose/transformTypography.js'
 import { checkAndEvaluateMath } from './checkAndEvaluateMath.js';
 import { mapDescriptionToComment } from './mapDescriptionToComment.js';
 import { transformColorModifiers } from './color-modifiers/transformColorModifiers.js';
+import { transformOpacity } from './transformOpacity.js';
 
 const isBrowser = typeof window === 'object';
 
@@ -38,6 +39,13 @@ export async function registerTransforms(sd: Core) {
         token.type,
       ),
     transformer: token => transformDimension(token.value),
+  });
+
+  _sd.registerTransform({
+    name: 'ts/opacity',
+    type: 'value',
+    matcher: token => token.type === 'opacity',
+    transformer: token => transformOpacity(token.value),
   });
 
   _sd.registerTransform({

--- a/src/transformOpacity.ts
+++ b/src/transformOpacity.ts
@@ -1,0 +1,18 @@
+/**
+ * Helper: Transforms opacity % to a decimal point number
+ * @example
+ * 50% -> 0.5
+ */
+export function transformOpacity(
+    value: string | number | undefined,
+  ): string | number | undefined {
+    if (value === undefined) {
+      return value;
+    }
+    if (`${value}`.endsWith('%')) {
+      const percentValue = `${value}`.slice(0, -1);
+      return parseFloat(percentValue) / 100;
+    }
+    return value;
+  }
+  


### PR DESCRIPTION
hey there!

I figured it's useful to transform opacity percentages that we are getting from the plugin to decimal point numbers to make them usable, handled in a similar fashion as the line-height transformation, although it might be interesting to create one 'Percentage to decimal point' transformer and re-use it for line heights, letter spacings and opacity in one go.