### PR TITLE
feat: rem based dimensions 

### DIFF
--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -1,5 +1,6 @@
 import { Core } from 'style-dictionary';
-import { transformDimension } from './transformDimension.js';
+import { transformPx } from './transformPx.js';
+import { transformRem } from './transformRem.js';
 import { transformHEXRGBa } from './transformHEXRGBa.js';
 import { transformShadow } from './transformShadow.js';
 import { transformFontWeights } from './transformFontWeights.js';
@@ -33,11 +34,19 @@ export async function registerTransforms(sd: Core) {
     name: 'ts/size/px',
     type: 'value',
     transitive: true,
+    matcher: token => token.type === 'borderWidth',
+    transformer: token => transformPx(token.value),
+  });
+
+  _sd.registerTransform({
+    name: 'ts/size/rem',
+    type: 'value',
+    transitive: true,
     matcher: token =>
-      ['sizing', 'spacing', 'borderRadius', 'borderWidth', 'fontSizes', 'dimension'].includes(
+      ['sizing', 'spacing', 'borderRadius', 'fontSizes', 'dimension'].includes(
         token.type,
       ),
-    transformer: token => transformDimension(token.value),
+    transformer: token => transformRem(token.value),
   });
 
   _sd.registerTransform({

--- a/src/transformPx.ts
+++ b/src/transformPx.ts
@@ -1,7 +1,7 @@
 /**
  * Helper: Transforms dimensions to px
  */
-export function transformDimension(value: string | undefined | number): string | undefined {
+export function transformPx(value: string | undefined | number): string | undefined {
   if (value === undefined) {
     return value;
   }

--- a/src/transformRem.ts
+++ b/src/transformRem.ts
@@ -1,0 +1,31 @@
+/**
+ * Helper: Transforms dimensions to px
+ */
+
+type TransformPxOptions = {
+  basePxFontSize: number; 
+}
+
+function getBasePxFontSize(options?: TransformPxOptions) {
+  return options?.basePxFontSize || 16;
+}
+
+export function transformRem(tokenValue: string | undefined | number, options?: TransformPxOptions): string | undefined {
+  if (tokenValue === undefined) {
+    return tokenValue;
+  }
+
+  if (`${tokenValue}`.endsWith('rem')) {
+    return `${tokenValue}`;
+  }
+
+  const value = parseFloat(`${tokenValue}`);
+  
+  if (value === 0) {
+    return '0';
+  }
+
+  const baseFont = getBasePxFontSize(options);
+
+  return `${value / baseFont}rem`;
+}


### PR DESCRIPTION
hey there!

using rem as a unit compared to using pixels will make the web a much better place for visually impaired users, as typography and dimensions scale based on the scaling the user defined in their browser settings.

To get some info on the topic I can suggest these sources:

* https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/
* https://www.youtube.com/watch?v=pKX7YnkyR8g

Our current project has a strong focus on accessibility - and while we created our own transformation on it I think the default provided by sd-transforms should be based on rem as well.

I excluded borders from this transformation as this can lead [browser specific render issues](https://stackoverflow.com/questions/33997943/0-1-rem-border-width-renders-differently-on-chrome-and-safari) and generally they offer no benefit to accessibility as borders aren't really content related, so there's no need for them to scale.

Let me know if you are open to the change so I can update the tests accordingly.