### PR TITLE
fix: CJS interop rollup option for handling default exports

### DIFF
--- a/.changeset/fuzzy-shoes-hug.md
+++ b/.changeset/fuzzy-shoes-hug.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Use Rollup output.interop for CJS output, to properly handle default exports in our CJS external dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@tokens-studio/types": "^0.2.1",
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.26.0",
         "@esm-bundle/chai": "^4.3.4-fix.0",
-        "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
-      "integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.1.0.tgz",
+      "integrity": "sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
     "@esm-bundle/chai": "^4.3.4-fix.0",
-    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-commonjs": "^24.1.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",

--- a/rollup/cjs.config.mjs
+++ b/rollup/cjs.config.mjs
@@ -23,6 +23,10 @@ export default {
     format: 'cjs',
     preserveModules: true,
     entryFileNames: '[name].cjs',
+    // Ensures that CJS default exports are imported properly (based on __esModule)
+    // If needed, can switch to 'compat' which checks for .default prop on the default export instead
+    // see https://rollupjs.org/configuration-options/#output-interop
+    interop: 'auto',
   },
   plugins: [nodeResolve(), typescript({ tsconfig: 'tsconfig.build.json', declaration: false })],
 };


### PR DESCRIPTION
fixes https://github.com/tokens-studio/sd-transforms/issues/111