### PR TITLE
fix return types of some token types

### DIFF
--- a/.changeset/empty-pots-call.md
+++ b/.changeset/empty-pots-call.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Fixed the return types of lineHeight, opacity and fontWeight to be number instead of string

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -18,7 +18,8 @@ export function transformTypographyForCSS(
   }
 
   let { fontFamily, fontWeight, fontSize, lineHeight } = value;
-  fontWeight = transformFontWeights(fontWeight);
+
+  fontWeight = fontWeight !== undefined ? `${transformFontWeights(fontWeight)}` : undefined;
   fontSize = transformDimension(checkAndEvaluateMath(fontSize));
   lineHeight = checkAndEvaluateMath(lineHeight);
   fontFamily = hasWhiteSpace(fontFamily) ? `'${fontFamily}'` : fontFamily;

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -11,7 +11,7 @@ import { hasWhiteSpace } from '../utils/has-whitespace.js';
  */
 
 export function transformTypographyForCSS(
-  value: Record<string, string | undefined> | undefined | string,
+  value: Record<string, string | undefined | number> | undefined | string,
 ): string | undefined {
   if (typeof value !== 'object') {
     return value;
@@ -19,10 +19,10 @@ export function transformTypographyForCSS(
 
   let { fontFamily, fontWeight, fontSize, lineHeight } = value;
 
-  fontWeight = fontWeight !== undefined ? `${transformFontWeights(fontWeight)}` : undefined;
+  fontWeight = transformFontWeights(fontWeight);
   fontSize = transformDimension(checkAndEvaluateMath(fontSize));
   lineHeight = checkAndEvaluateMath(lineHeight);
-  fontFamily = hasWhiteSpace(fontFamily) ? `'${fontFamily}'` : fontFamily;
+  fontFamily = hasWhiteSpace(fontFamily as string | undefined) ? `'${fontFamily}'` : fontFamily;
 
   return `${isNothing(fontWeight) ? 400 : fontWeight} ${isNothing(fontSize) ? '16px' : fontSize}/${
     isNothing(lineHeight) ? 1 : lineHeight

--- a/src/transformFontWeights.ts
+++ b/src/transformFontWeights.ts
@@ -28,13 +28,13 @@ export const fontWeightMap = {
 /**
  * Helper: Transforms fontweight keynames to fontweight numbers (100, 200, 300 ... 900)
  */
-export function transformFontWeights(value: string | undefined | number): string | undefined {
+export function transformFontWeights(
+  value: string | undefined | number,
+): number | string | undefined {
   if (value === undefined) {
     return value;
   }
   const mapped = fontWeightMap[`${value}`.toLowerCase()];
-  if (mapped) {
-    return `${mapped}`;
-  }
-  return `${value}`;
+
+  return mapped ?? value;
 }

--- a/src/transformLineHeight.ts
+++ b/src/transformLineHeight.ts
@@ -5,10 +5,12 @@ import { percentageToDecimal } from './utils/percentageToDecimal.js';
  * @example
  * 150% -> 1.5
  */
-export function transformLineHeight(value: string | number | undefined): string | undefined {
+export function transformLineHeight(
+  value: string | number | undefined,
+): string | number | undefined {
   if (value === undefined) {
     return value;
   }
   const decimal = percentageToDecimal(value);
-  return typeof decimal === 'string' || isNaN(decimal) ? `${value}` : `${decimal}`;
+  return typeof decimal === 'string' || isNaN(decimal) ? `${value}` : decimal;
 }

--- a/src/transformOpacity.ts
+++ b/src/transformOpacity.ts
@@ -10,5 +10,5 @@ export function transformOpacity(value: string | number | undefined): string | n
     return value;
   }
   const decimal = percentageToDecimal(value);
-  return typeof decimal === 'string' || isNaN(decimal) ? `${value}` : `${decimal}`;
+  return typeof decimal === 'string' || isNaN(decimal) ? value : decimal;
 }

--- a/src/utils/is-nothing.ts
+++ b/src/utils/is-nothing.ts
@@ -1,4 +1,4 @@
-export function isNothing(value: string | null | undefined): boolean {
+export function isNothing(value: string | number | null | undefined): boolean {
   if (value == null || value === '') {
     return true;
   }

--- a/test/spec/transformFontWeights.spec.ts
+++ b/test/spec/transformFontWeights.spec.ts
@@ -7,7 +7,7 @@ runTransformSuite(transformFontWeights as (value: unknown) => unknown);
 describe('transform dimension', () => {
   it('transforms fontweight keynames to fontweight numbers', () => {
     Object.entries(fontWeightMap).forEach(([keyname, number]) => {
-      expect(transformFontWeights(keyname)).to.equal(`${number}`);
+      expect(transformFontWeights(keyname)).to.equal(number);
     });
   });
 
@@ -17,6 +17,6 @@ describe('transform dimension', () => {
   });
 
   it('supports case-insensitive input', () => {
-    expect(transformFontWeights('Light')).to.equal('300');
+    expect(transformFontWeights('Light')).to.equal(300);
   });
 });

--- a/test/spec/transformLineHeight.spec.ts
+++ b/test/spec/transformLineHeight.spec.ts
@@ -6,7 +6,7 @@ runTransformSuite(transformLineHeight as (value: unknown) => unknown);
 
 describe('transform line height', () => {
   it('transforms line-height % to unit-less decimal value', () => {
-    expect(transformLineHeight('50%')).to.equal('0.5');
+    expect(transformLineHeight('50%')).to.equal(0.5);
   });
 
   it("does not transform line-height if it doesn't end with %", () => {

--- a/test/spec/transformOpacity.spec.ts
+++ b/test/spec/transformOpacity.spec.ts
@@ -6,7 +6,7 @@ runTransformSuite(transformOpacity as (value: unknown) => unknown);
 
 describe('transform opacity', () => {
   it('transforms opacity % to unit-less decimal value', () => {
-    expect(transformOpacity('50%')).to.equal('0.5');
+    expect(transformOpacity('50%')).to.equal(0.5);
   });
 
   it("does not transform opacity if it doesn't end with %", () => {


### PR DESCRIPTION
This fixes the return types of some of the token types. 
Previously, things such as fontWeight token types were returned as `string`, where they should be `number`.  (from my viewpoint at least 😄.

Fixed return type:
- opacity
- lineHeight
- fontWeight