### PR TITLE
bugfix: Strip newlines from comments to ensure valid output

### DIFF
--- a/src/mapDescriptionToComment.ts
+++ b/src/mapDescriptionToComment.ts
@@ -7,6 +7,6 @@ import { DesignToken } from 'style-dictionary';
 export function mapDescriptionToComment(token: DesignToken): DesignToken {
   // intentional mutation of the original object
   const _t = token;
-  _t.comment = _t.description;
+  _t.comment = _t.description.replace(/\r?\n|\r/g, ' '); // Strip out newline and carriage returns, replacing them with space
   return _t;
 }


### PR DESCRIPTION
Currently, having `/n` in a token description will cause the `ts/descriptionToComment` transform to create invalid output. This PR just strips `\n` (and also `\r` to be safe) from the comments.

## Problematic token
```json
"heading-large": {
        "value": {
          "fontFamily": "Roboto",
          "fontWeight": "Regular",
          "lineHeight": "36",
          "fontSize": "28",
          "letterSpacing": "0"
        },
        "type": "typography",
        "description": "The headline text styles are intended for a wide range of use cases when large text is needed including:\n\nPage headings/titles,\nSection headings/titles,\nCard headings/titles"
      },
```

## Current broken output (Javascript)
```js
export const GENERAC_HEADING_LARGE = "400 28px/36 Roboto"; // The headline text styles are intended for a wide range of use cases when large text is needed including:

Page headings/titles,
Section headings/titles,
Card headings/titles
```
![image](https://github.com/tokens-studio/sd-transforms/assets/11964962/63df1185-969e-4bed-8e70-babc9c34c636)

## Fixed output after this PR
```js
export const GENERAC_HEADING_LARGE = "400 28px/36 Roboto"; // The headline text styles are intended for a wide range of use cases when large text is needed including:  Page headings/titles, Section headings/titles, Card headings/titles
```
![image](https://github.com/tokens-studio/sd-transforms/assets/11964962/ea93676b-301d-4014-ae64-870d16d4c1da)
