### PR TITLE
fix: Strip line breaks from comments to ensure valid output

### DIFF
--- a/.changeset/three-onions-relate.md
+++ b/.changeset/three-onions-relate.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Fixes comment transformer for descriptions with line breaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Unit tests should provide 100% coverage. Use:
 
 ```sh
 npm run test
-npm run test:view:coverage
+npm run test:unit:coverage
 ```
 
 To run the tests and view the coverage report, to see which things are untested.

--- a/src/mapDescriptionToComment.ts
+++ b/src/mapDescriptionToComment.ts
@@ -7,6 +7,6 @@ import { DesignToken } from 'style-dictionary';
 export function mapDescriptionToComment(token: DesignToken): DesignToken {
   // intentional mutation of the original object
   const _t = token;
-  _t.comment = _t.description;
+  _t.comment = _t.description.replace(/\r?\n|\r/g, ' '); // Strip out newline and carriage returns, replacing them with space
   return _t;
 }

--- a/test/spec/mapDescriptionToComment.spec.ts
+++ b/test/spec/mapDescriptionToComment.spec.ts
@@ -15,5 +15,21 @@ describe('map description to comment', () => {
       description: 'Some description about the token',
       comment: 'Some description about the token',
     });
+
+    expect(
+      mapDescriptionToComment({
+        type: 'dimension',
+        value: '10px',
+        description:
+          'This is the first line.\nThis is the second line.\rThis is the third line.\r\nThis is the fourth line.',
+      }),
+    ).to.eql({
+      type: 'dimension',
+      value: '10px',
+      description:
+        'This is the first line.\nThis is the second line.\rThis is the third line.\r\nThis is the fourth line.',
+      comment:
+        'This is the first line. This is the second line. This is the third line. This is the fourth line.',
+    });
   });
 });


### PR DESCRIPTION
Currently, having `/n` in a token description will cause the `ts/descriptionToComment` transform to create invalid output. This PR just strips `\n` (and also `\r` to be safe) from the comments.

Also fixes a npm command typo in `CONTRIBUTING.md`

## Problematic token
```json
"heading-large": {
        "value": {
          "fontFamily": "Roboto",
          "fontWeight": "Regular",
          "lineHeight": "36",
          "fontSize": "28",
          "letterSpacing": "0"
        },
        "type": "typography",
        "description": "The headline text styles are intended for a wide range of use cases when large text is needed including:\n\nPage headings/titles,\nSection headings/titles,\nCard headings/titles"
      },
```

## Current broken output (Javascript)
```js
export const GENERAC_HEADING_LARGE = "400 28px/36 Roboto"; // The headline text styles are intended for a wide range of use cases when large text is needed including:

Page headings/titles,
Section headings/titles,
Card headings/titles
```
![image](https://github.com/tokens-studio/sd-transforms/assets/11964962/63df1185-969e-4bed-8e70-babc9c34c636)

## Fixed output after this PR
```js
export const GENERAC_HEADING_LARGE = "400 28px/36 Roboto"; // The headline text styles are intended for a wide range of use cases when large text is needed including:  Page headings/titles, Section headings/titles, Card headings/titles
```
![image](https://github.com/tokens-studio/sd-transforms/assets/11964962/ea93676b-301d-4014-ae64-870d16d4c1da)

## Tests pass
![image](https://github.com/tokens-studio/sd-transforms/assets/11964962/7e935d47-2bc6-48a5-b893-6057964e56d1)

