### PR TITLE
fix(transformHEXRGBAForCSS): allow whitespacing surrounding the hex code

### DIFF
--- a/.changeset/olive-cooks-destroy.md
+++ b/.changeset/olive-cooks-destroy.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Patches the transformHEXRGBa function to allow for whitespaces surrounding the HEX code. The Tokens Studio plugin automatically adds these whitespaces when working with aliases so this patch removes the need for manually having to remove those whitespaces.

--- a/src/css/transformHEXRGBa.ts
+++ b/src/css/transformHEXRGBa.ts
@@ -9,7 +9,7 @@ export function transformHEXRGBaForCSS(value: string | undefined): string | unde
   if (value === undefined) {
     return value;
   }
-  const match = /rgba\((?<hex>#.+?),\s*?(?<alpha>\d.*?)\)/g.exec(value);
+  const match = /rgba\(\s*(?<hex>#.+?)\s*,\s*?(?<alpha>\d.*?)\)/g.exec(value);
   if (match && match.groups) {
     const { hex, alpha } = match.groups;
     try {

--- a/test/spec/css/transformHEXRGBa.spec.ts
+++ b/test/spec/css/transformHEXRGBa.spec.ts
@@ -9,6 +9,10 @@ describe('transform HEXRGBa', () => {
     expect(transformHEXRGBaForCSS('rgba(#ABC123, 0.5)')).to.equal('rgba(171, 193, 35, 0.5)');
   });
 
+  it("transforms Figma's hex code RGBA to actual RGBA format regardless of whitespacing", () => {
+    expect(transformHEXRGBaForCSS('rgba( #ABC123 , 0.5)')).to.equal('rgba(171, 193, 35, 0.5)');
+  });
+
   it('does not transform the color if it doesnt match the regex', () => {
     expect(transformHEXRGBaForCSS('foo')).to.equal('foo');
   });


### PR DESCRIPTION
The regex to check for rgba hex strings allowed for whitespaces between the comma and the alpha value but no other spacing was allowed: `rgba\((?<hex>#.+?),\s*?(?<alpha>\d.*?)\)`

However, in Tokens Studio upon for example setting a rgba value where the hex code refers to another token, the plug-in will automatically add a space before and after the token. This means that you end up with something like `rgba( {base.Shadow} , 0.5)` which will no longer work with the aforementioned regex.

For now, the fix is that our designers make sure in their way of working that they manually remove those whitespaces but that's an extra step and prone to human error. It would be much easier to allow for whitespacing before and after the hex value with a regex like: `rgba\(\s*(?<hex>#.+?)\s*,\s*?(?<alpha>\d.*?)\)`.