### PR TITLE
Add transform: font family token value to valid CSS

### DIFF
--- a/.changeset/eighty-eggs-smile.md
+++ b/.changeset/eighty-eggs-smile.md
@@ -1,0 +1,7 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Add value transform `ts/typography/css/fontFamily` to font-families which adds quotes if it has white space. The source
+value will then match with how it's rendered in the composite typography token value. `outputReferences: true` will now replace
+the quoted value with the reference. Previously, the reference was wrapped in quotes.

--- a/.changeset/tidy-pots-enjoy.md
+++ b/.changeset/tidy-pots-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': minor
+---
+
+BREAKING: change name of ts/type/fontWeight transform to -> ts/typography/fontWeight, for consistency's sake.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Generic:
 - Transform dimensions tokens to have `px` as a unit when missing (transitive) -> `ts/size/px`
 - Transform opacity from `%` to number between `0` and `1` -> `ts/opacity`
 - Transform lineheight from `%` to unitless (150% -> 1.5) -> `ts/size/lineheight`
-- Transform fontweight from keynames to fontweight numbers (100, 200, 300 ... 900) -> `ts/type/fontWeight`
+- Transform fontweight from keynames to fontweight numbers (100, 200, 300 ... 900) -> `ts/typography/fontWeight`
 - Transform color modifiers from Tokens Studio to color values -> `ts/color/modifiers`
 
 CSS:
 
 - Transform letterspacing from `%` to `em` -> `ts/size/css/letterspacing`
 - Transform colors to `rgba()` format -> `ts/color/css/hexrgba`
-- Transform font name into valid CSS, quoting if necessary. Fixes `outputReferences: true` in css shorthand -> `ts/type/css/quoteFontName`
+- Transform font family into valid CSS, adding single quotes if necessary -> `ts/typography/css/fontFamily`
 - Transform typography objects to CSS shorthand -> `ts/typography/css/shorthand`
 - Transform Tokens Studio shadow objects to CSS shadow shorthand -> `ts/shadow/css/shorthand`
 - Transform border objects to CSS border shorthand -> `ts/border/css/shorthand`
@@ -187,10 +187,10 @@ const sd = StyleDictionary.extend({
         'ts/size/px',
         'ts/opacity',
         'ts/size/lineheight',
-        'ts/type/fontWeight',
+        'ts/typography/fontWeight',
         'ts/resolveMath',
         'ts/size/css/letterspacing',
-        'ts/type/css/quoteFontName',
+        'ts/typography/css/fontFamily',
         'ts/typography/css/shorthand',
         'ts/border/css/shorthand',
         'ts/shadow/css/shorthand',

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ CSS:
 
 - Transform letterspacing from `%` to `em` -> `ts/size/css/letterspacing`
 - Transform colors to `rgba()` format -> `ts/color/css/hexrgba`
+- Transform font name into valid CSS, quoting if necessary. Fixes `outputReferences: true` in css shorthand -> `ts/type/css/quoteFontName`
 - Transform typography objects to CSS shorthand -> `ts/typography/css/shorthand`
 - Transform Tokens Studio shadow objects to CSS shadow shorthand -> `ts/shadow/css/shorthand`
 - Transform border objects to CSS border shorthand -> `ts/border/css/shorthand`
@@ -189,6 +190,7 @@ const sd = StyleDictionary.extend({
         'ts/type/fontWeight',
         'ts/resolveMath',
         'ts/size/css/letterspacing',
+        'ts/type/css/quoteFontName',
         'ts/typography/css/shorthand',
         'ts/border/css/shorthand',
         'ts/shadow/css/shorthand',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Custom transforms for Style-Dictionary, to work with Design Tokens that are exported from Tokens Studio",
   "license": "MIT",
   "author": "Joren Broekema <joren.broekema@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.9.10",
+  "version": "0.9.9",
   "description": "Custom transforms for Style-Dictionary, to work with Design Tokens that are exported from Tokens Studio",
   "license": "MIT",
   "author": "Joren Broekema <joren.broekema@gmail.com>",

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -8,15 +8,19 @@ export function hasWhiteSpace(value: string): boolean {
   return whiteSpaceRegex.test(value);
 }
 
+function isAlreadyQuoted(value: string): boolean {
+  return value.startsWith("'") && value.endsWith("'");
+}
+
 export function isCommaSeparated(value: string): boolean {
   return value.includes(',');
 }
 
 function quoteWrapWhitespacedFont(fontString: string) {
-  return hasWhiteSpace(fontString) ? `'${fontString}'` : fontString;
+  return hasWhiteSpace(fontString) && !isAlreadyQuoted(fontString) ? `'${fontString}'` : fontString;
 }
 
-function processFontFamily(fontFamily: string | undefined) {
+export function processFontFamily(fontFamily: string | undefined) {
   if (isNothing(fontFamily)) {
     return 'sans-serif';
   }

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -23,10 +23,10 @@ export const transforms = [
   'ts/size/px',
   'ts/opacity',
   'ts/size/lineheight',
-  'ts/type/fontWeight',
+  'ts/typography/fontWeight',
   'ts/resolveMath',
   'ts/size/css/letterspacing',
-  'ts/type/css/quoteFontName',
+  'ts/typography/css/fontFamily',
   'ts/typography/css/shorthand',
   'ts/border/css/shorthand',
   'ts/shadow/css/shorthand',
@@ -104,14 +104,14 @@ export async function registerTransforms(sd: Core, transformOpts?: TransformOpti
   });
 
   _sd.registerTransform({
-    name: 'ts/type/fontWeight',
+    name: 'ts/typography/fontWeight',
     type: 'value',
     matcher: token => token.type === 'fontWeights',
     transformer: token => transformFontWeights(token.value),
   });
 
   _sd.registerTransform({
-    name: 'ts/type/css/quoteFontName',
+    name: 'ts/typography/css/fontFamily',
     type: 'value',
     matcher: token => token.type === 'fontFamilies',
     transformer: token => processFontFamily(token.value),

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -24,9 +24,9 @@ export const transforms = [
   'ts/opacity',
   'ts/size/lineheight',
   'ts/type/fontWeight',
-  'ts/type/quoteFontName',
   'ts/resolveMath',
   'ts/size/css/letterspacing',
+  'ts/type/css/quoteFontName',
   'ts/typography/css/shorthand',
   'ts/border/css/shorthand',
   'ts/shadow/css/shorthand',
@@ -111,7 +111,7 @@ export async function registerTransforms(sd: Core, transformOpts?: TransformOpti
   });
 
   _sd.registerTransform({
-    name: 'ts/type/quoteFontName',
+    name: 'ts/type/css/quoteFontName',
     type: 'value',
     matcher: token => token.type === 'fontFamilies',
     transformer: token => processFontFamily(token.value),

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -5,7 +5,7 @@ import { transformShadowForCSS } from './css/transformShadow.js';
 import { transformFontWeights } from './transformFontWeights.js';
 import { transformLetterSpacingForCSS } from './css/transformLetterSpacing.js';
 import { transformLineHeight } from './transformLineHeight.js';
-import { transformTypographyForCSS } from './css/transformTypography.js';
+import { processFontFamily, transformTypographyForCSS } from './css/transformTypography.js';
 import { transformTypographyForCompose } from './compose/transformTypography.js';
 import { transformBorderForCSS } from './css/transformBorder.js';
 import { checkAndEvaluateMath } from './checkAndEvaluateMath.js';
@@ -24,6 +24,7 @@ export const transforms = [
   'ts/opacity',
   'ts/size/lineheight',
   'ts/type/fontWeight',
+  'ts/type/quoteFontName',
   'ts/resolveMath',
   'ts/size/css/letterspacing',
   'ts/typography/css/shorthand',
@@ -107,6 +108,13 @@ export async function registerTransforms(sd: Core, transformOpts?: TransformOpti
     type: 'value',
     matcher: token => token.type === 'fontWeights',
     transformer: token => transformFontWeights(token.value),
+  });
+
+  _sd.registerTransform({
+    name: 'ts/type/quoteFontName',
+    type: 'value',
+    matcher: token => token.type === 'fontFamilies',
+    transformer: token => processFontFamily(token.value),
   });
 
   /**

--- a/test/spec/css/transformFontFamilies.spec.ts
+++ b/test/spec/css/transformFontFamilies.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from '@esm-bundle/chai';
+import { processFontFamily } from '../../../src/css/transformTypography.js';
+
+describe('process font family', () => {
+  it('transforms font-family to have single quotes around multi-word font-families', () => {
+    expect(processFontFamily('')).to.equal(`sans-serif`);
+    expect(processFontFamily('Arial, sans-serif')).to.equal(`Arial, sans-serif`);
+    expect(processFontFamily('Arial Black, sans-serif')).to.equal(`'Arial Black', sans-serif`);
+    expect(processFontFamily('Arial Black, Times New Roman, Foo, sans-serif')).to.equal(
+      `'Arial Black', 'Times New Roman', Foo, sans-serif`,
+    );
+    expect(processFontFamily(`'Arial Black', Times New Roman, Foo, sans-serif`)).to.equal(
+      `'Arial Black', 'Times New Roman', Foo, sans-serif`,
+    );
+  });
+});


### PR DESCRIPTION
Where a `type` composite token referenced a css variable for font name (and the source font needed quoting)
and `outputReferences` is set to true, the output css variable incorrectly retained the quotes around the `'var()'`.

For example:
```css
  --cone-type-600-mono: var(--global-font-weight-regular) var(--cone-font-size-300)/var(--cone-line-height-2x-dense) 'var(--cone-font-sf-mono)';
```
instead of
```css
  --cone-type-600-mono: var(--global-font-weight-regular) var(--cone-font-size-300)/var(--cone-line-height-2x-dense) var(--cone-font-sf-mono);
```

I made a workaround
```javascript
// The style dictionary transformer wraps font family names which contains spaces in quotes.
// Because we have outputReferences set to true, the formatter replaces the quote *contents* with a reference var(...),
// but it leaves the quotes.
// What's probably happening is that the formatter is replacing the source value with the source name... except there are no quotes
// in the source name; those are added by the transform.
// A fix to tokens-studio would probably be to add the quotes to the value in the transform, and update quoteWrapWhitespacedFont to
// check.
styleDictionary.registerTransform({
	type: 'value',
	transitive: true,
	name: 'fixFontVarReference',
	matcher: token => token.type == 'typography' && token.original.value?.fontFamily?.startsWith('{'),
	transformer: token => {
		return token.value.replace(/'([^'].*)'/, convertTokenReferenceToCss(token.original.value.fontFamily));
	}
})
```
And than checked my theory in this PR. It worked! So here it is.
