### PR TITLE
add a parser function to add fontStyle to typography tokens

### DIFF
--- a/.changeset/tiny-poets-doubt.md
+++ b/.changeset/tiny-poets-doubt.md
@@ -2,4 +2,4 @@
 '@tokens-studio/sd-transforms': minor
 ---
 
-BREAKING: add parser that extracts "italic" from fontWeight and adds it as a separate property on Typography tokens object values.
+BREAKING: add parser that extracts fontStyle from fontWeight and adds it as a separate property on Typography tokens object values.

--- a/.changeset/tiny-poets-doubt.md
+++ b/.changeset/tiny-poets-doubt.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': minor
+---
+
+BREAKING: add parser that extracts "italic" from fontWeight and adds it as a separate property on Typography tokens object values.

--- a/.changeset/wild-actors-roll.md
+++ b/.changeset/wild-actors-roll.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Properly take into account fontStyle inside fontWeights values, in both the fontWeights and CSS typography shorthand transforms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "@tokens-studio/types": "^0.2.4",

--- a/src/checkAndEvaluateMath.ts
+++ b/src/checkAndEvaluateMath.ts
@@ -1,5 +1,6 @@
 import { Parser } from 'expr-eval';
 import { parse, reduceExpression } from 'postcss-calc-ast-parser';
+import { isAlreadyQuoted } from './css/transformTypography.js';
 
 const mathChars = ['+', '-', '*', '/'];
 
@@ -86,11 +87,19 @@ function parseAndReduce(expr: string): string {
   let evaluated;
   try {
     evaluated = parser.evaluate(unitlessExpr);
+
+    // In CSS shorthand with white-spaced font-family that has single quotes around it
+    // parser ends up evaluating that and removing the single quotes. If that happens, revert that change.
+    if (evaluated && isAlreadyQuoted(unitlessExpr)) {
+      evaluated = `'${evaluated}'`;
+    }
   } catch (ex) {
     return expr;
   }
   // Put back the px unit if needed and if reduced doesn't come with one
-  return `${Number.parseFloat(evaluated.toFixed(3))}${unit ?? (hasPx ? 'px' : '')}`;
+  return `${typeof evaluated !== 'string' ? Number.parseFloat(evaluated.toFixed(3)) : evaluated}${
+    unit ?? (hasPx ? 'px' : '')
+  }`;
 }
 
 export function checkAndEvaluateMath(expr: string | number | undefined): string | undefined {

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -8,7 +8,7 @@ export function hasWhiteSpace(value: string): boolean {
   return whiteSpaceRegex.test(value);
 }
 
-function isAlreadyQuoted(value: string): boolean {
+export function isAlreadyQuoted(value: string): boolean {
   return value.startsWith("'") && value.endsWith("'");
 }
 
@@ -48,12 +48,15 @@ export function transformTypographyForCSS(
   }
 
   let { fontFamily, fontWeight, fontSize, lineHeight } = value;
+  const { fontStyle } = value;
   fontSize = transformDimension(checkAndEvaluateMath(fontSize));
   lineHeight = checkAndEvaluateMath(lineHeight);
   fontWeight = transformFontWeights(fontWeight);
   fontFamily = processFontFamily(fontFamily as string | undefined);
 
-  return `${isNothing(fontWeight) ? 400 : fontWeight} ${isNothing(fontSize) ? '16px' : fontSize}/${
+  return `${isNothing(fontWeight) ? 400 : fontWeight}${
+    isNothing(fontStyle) ? '' : ` ${fontStyle}`
+  } ${isNothing(fontSize) ? '16px' : fontSize}/${
     isNothing(lineHeight) ? 1 : lineHeight
   } ${fontFamily}`;
 }

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -12,10 +12,13 @@ function recurse(
     const token = slice[key];
     const { type, value } = token;
     if (type === 'typography') {
-      let fontWeight;
+      if (typeof value !== 'object') {
+        continue;
+      }
+      let fontWeight = value.fontWeight;
 
-      if (usesReference(value)) {
-        let ref = { value: value } as SingleToken<false>;
+      if (usesReference(fontWeight)) {
+        let ref = { value: fontWeight } as SingleToken<false>;
         while (ref && ref.value && typeof ref.value === 'string' && usesReference(ref.value)) {
           try {
             ref = Object.fromEntries(
@@ -26,10 +29,7 @@ function recurse(
             return;
           }
         }
-        fontWeight = (ref.value as TokenTypographyValue).fontWeight;
-        (token as SingleToken<false>).value = ref.value;
-      } else if (typeof value === 'object') {
-        fontWeight = value.fontWeight;
+        fontWeight = ref.value as string;
       }
 
       // cast it to TokenTypographyValue now that we've resolved references all the way, we know it cannot be a string anymore.
@@ -41,7 +41,7 @@ function recurse(
         if (fontStyleMatch) {
           // @ts-expect-error fontStyle is not a property that exists on Typography Tokens, we just add it ourselves
           tokenValue.fontStyle = fontStyleMatch[0].toLowerCase();
-          tokenValue.fontWeight = tokenValue.fontWeight?.replace(fontStyleReg, '').trim();
+          tokenValue.fontWeight = fontWeight?.replace(fontStyleReg, '').trim();
         }
       }
     } else if (typeof token === 'object') {

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -1,0 +1,53 @@
+import { DeepKeyTokenMap, SingleToken, TokenTypographyValue } from '@tokens-studio/types';
+// @ts-expect-error no type exported for this function
+import getReferences from 'style-dictionary/lib/utils/references/getReferences.js';
+// @ts-expect-error no type exported for this function
+import usesReference from 'style-dictionary/lib/utils/references/usesReference.js';
+
+function recurse(
+  slice: DeepKeyTokenMap<false>,
+  boundGetRef: (ref: string) => Array<SingleToken<false>>,
+) {
+  for (const key in slice) {
+    const token = slice[key];
+    const { type, value } = token;
+    if (type === 'typography') {
+      let fontWeight;
+
+      if (usesReference(value)) {
+        let ref = { value: value } as SingleToken<false>;
+        while (ref && ref.value && typeof ref.value === 'string' && usesReference(ref.value)) {
+          try {
+            ref = Object.fromEntries(
+              Object.entries(boundGetRef(ref.value)[0]).map(([k, v]) => [k, v]),
+            ) as SingleToken<false>;
+          } catch (e) {
+            console.warn(`Warning: could not resolve reference ${ref.value}`);
+            return;
+          }
+        }
+        fontWeight = (ref.value as TokenTypographyValue).fontWeight;
+        (token as SingleToken<false>).value = ref.value;
+      } else if (typeof value === 'object') {
+        fontWeight = value.fontWeight;
+      }
+
+      // cast it to TokenTypographyValue now that we've resolved references all the way, we know it cannot be a string anymore.
+      const tokenValue = value as TokenTypographyValue;
+      if (fontWeight && fontWeight.toLowerCase().indexOf('italic') > -1) {
+        // @ts-expect-error fontStyle is not a property that exists on Typography Tokens, we just add it ourselves
+        tokenValue.fontStyle = 'italic';
+        tokenValue.fontWeight = tokenValue.fontWeight?.replace(/italic$/i, '').trim();
+      }
+    } else if (typeof token === 'object') {
+      recurse(token as unknown as DeepKeyTokenMap<false>, boundGetRef);
+    }
+  }
+}
+
+export function addFontStyles(dictionary: DeepKeyTokenMap<false>): DeepKeyTokenMap<false> {
+  const copy = { ...dictionary };
+  const boundGetRef = getReferences.bind({ properties: copy });
+  recurse(copy, boundGetRef);
+  return copy;
+}

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -3,6 +3,7 @@ import { DeepKeyTokenMap, SingleToken, TokenTypographyValue } from '@tokens-stud
 import getReferences from 'style-dictionary/lib/utils/references/getReferences.js';
 // @ts-expect-error no type exported for this function
 import usesReference from 'style-dictionary/lib/utils/references/usesReference.js';
+import { fontWeightReg } from '../transformFontWeights.js';
 
 function recurse(
   slice: DeepKeyTokenMap<false>,
@@ -36,12 +37,11 @@ function recurse(
       const tokenValue = value as TokenTypographyValue;
 
       if (fontWeight) {
-        const fontStyleReg = /(italic|oblique|normal)$/gi;
-        const fontStyleMatch = fontWeight.match(fontStyleReg);
-        if (fontStyleMatch) {
+        const fontStyleMatch = fontWeight.match(fontWeightReg);
+        if (fontStyleMatch?.groups?.weight && fontStyleMatch.groups.style) {
           // @ts-expect-error fontStyle is not a property that exists on Typography Tokens, we just add it ourselves
-          tokenValue.fontStyle = fontStyleMatch[0].toLowerCase();
-          tokenValue.fontWeight = fontWeight?.replace(fontStyleReg, '').trim();
+          tokenValue.fontStyle = fontStyleMatch.groups.style.toLowerCase();
+          tokenValue.fontWeight = fontStyleMatch?.groups?.weight;
         }
       }
     } else if (typeof token === 'object') {

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -34,10 +34,15 @@ function recurse(
 
       // cast it to TokenTypographyValue now that we've resolved references all the way, we know it cannot be a string anymore.
       const tokenValue = value as TokenTypographyValue;
-      if (fontWeight && fontWeight.toLowerCase().indexOf('italic') > -1) {
-        // @ts-expect-error fontStyle is not a property that exists on Typography Tokens, we just add it ourselves
-        tokenValue.fontStyle = 'italic';
-        tokenValue.fontWeight = tokenValue.fontWeight?.replace(/italic$/i, '').trim();
+
+      if (fontWeight) {
+        const fontStyleReg = /(italic|oblique|normal)$/gi;
+        const fontStyleMatch = fontWeight.match(fontStyleReg);
+        if (fontStyleMatch) {
+          // @ts-expect-error fontStyle is not a property that exists on Typography Tokens, we just add it ourselves
+          tokenValue.fontStyle = fontStyleMatch[0].toLowerCase();
+          tokenValue.fontWeight = tokenValue.fontWeight?.replace(fontStyleReg, '').trim();
+        }
       }
     } else if (typeof token === 'object') {
       recurse(token as unknown as DeepKeyTokenMap<false>, boundGetRef);

--- a/src/parsers/expand-composites.ts
+++ b/src/parsers/expand-composites.ts
@@ -29,6 +29,7 @@ const typeMaps = {
     fontWeight: 'fontWeights',
     lineHeight: 'lineHeights',
     fontSize: 'fontSizes',
+    fontStyle: 'fontStyles',
   },
 };
 

--- a/src/registerTransforms.ts
+++ b/src/registerTransforms.ts
@@ -15,6 +15,7 @@ import { TransformOptions } from './TransformOptions.js';
 import { expandComposites } from './parsers/expand-composites.js';
 import { excludeParentKeys } from './parsers/exclude-parent-keys.js';
 import { transformOpacity } from './transformOpacity.js';
+import { addFontStyles } from './parsers/add-font-styles.js';
 
 const isBrowser = typeof window === 'object';
 
@@ -59,7 +60,8 @@ export async function registerTransforms(sd: Core, transformOpts?: TransformOpti
       parse: ({ filePath, contents }) => {
         const obj = JSON.parse(contents);
         const excluded = excludeParentKeys(obj, transformOpts);
-        const expanded = expandComposites(excluded, filePath, transformOpts);
+        const withFontStyles = addFontStyles(excluded);
+        const expanded = expandComposites(withFontStyles, filePath, transformOpts);
         return expanded;
       },
     });

--- a/src/transformFontWeights.ts
+++ b/src/transformFontWeights.ts
@@ -25,6 +25,8 @@ export const fontWeightMap = {
   extrafett: 900,
 };
 
+export const fontWeightReg = /(?<weight>.+?)\s?(?<style>italic|oblique|normal)?$/i;
+
 /**
  * Helper: Transforms fontweight keynames to fontweight numbers (100, 200, 300 ... 900)
  */
@@ -34,7 +36,15 @@ export function transformFontWeights(
   if (value === undefined) {
     return value;
   }
-  const mapped = fontWeightMap[`${value}`.toLowerCase()];
+  const match = `${value}`.match(fontWeightReg);
+
+  let mapped;
+  if (match?.groups?.weight) {
+    mapped = fontWeightMap[match?.groups?.weight.toLowerCase()];
+    if (match.groups.style) {
+      mapped = `${mapped} ${match.groups.style.toLowerCase()}`;
+    }
+  }
 
   return mapped ?? value;
 }

--- a/test/integration/expand-composition.test.ts
+++ b/test/integration/expand-composition.test.ts
@@ -51,6 +51,7 @@ describe('expand composition tokens', () => {
 
   it('only expands composition tokens by default', async () => {
     const file = await promises.readFile(outputFilePath, 'utf-8');
+
     expect(file).to.include(
       `
   --sdCompositionSize: 24px;
@@ -61,11 +62,12 @@ describe('expand composition tokens', () => {
   --sdCompositionHeaderFontFamilies: Roboto;
   --sdCompositionHeaderFontSizes: 96px;
   --sdCompositionHeaderFontWeights: 700;
-  --sdTypography: 500 26px/1.25 Arial;
+  --sdTypography: 800 italic 26px/1.25 Arial;
+  --sdFontWeightRef: 800 italic;
   --sdBorder: 4px solid #FFFF00;
   --sdShadowSingle: inset 0 4px 10px 0 rgba(0,0,0,0.4);
   --sdShadowDouble: inset 0 4px 10px 0 rgba(0,0,0,0.4), 0 8px 12px 5px rgba(0,0,0,0.4);
-  --sdRef: 500 26px/1.25 Arial;`,
+  --sdRef: 800 italic 26px/1.25 Arial;`,
     );
   });
 
@@ -91,7 +93,7 @@ describe('expand composition tokens', () => {
   --sdCompositionHeaderFontSizes: 96px;
   --sdCompositionHeaderFontWeights: 700;
   --sdTypographyFontFamily: Arial;
-  --sdTypographyFontWeight: 500;
+  --sdTypographyFontWeight: 800;
   --sdTypographyLineHeight: 1.25;
   --sdTypographyFontSize: 26px;
   --sdTypographyLetterSpacing: 0;
@@ -99,6 +101,8 @@ describe('expand composition tokens', () => {
   --sdTypographyParagraphIndent: 0;
   --sdTypographyTextDecoration: none;
   --sdTypographyTextCase: none;
+  --sdTypographyFontStyle: italic;
+  --sdFontWeightRef: 800 italic;
   --sdBorderColor: #FFFF00;
   --sdBorderWidth: 4px;
   --sdBorderStyle: solid;
@@ -136,7 +140,7 @@ describe('expand composition tokens', () => {
     expect(file).to.include(
       `
   --sdRefFontFamily: Arial;
-  --sdRefFontWeight: 500;
+  --sdRefFontWeight: 800;
   --sdRefLineHeight: 1.25;
   --sdRefFontSize: 26px;
   --sdRefLetterSpacing: 0;
@@ -144,15 +148,17 @@ describe('expand composition tokens', () => {
   --sdRefParagraphIndent: 0;
   --sdRefTextDecoration: none;
   --sdRefTextCase: none;
+  --sdRefFontStyle: italic;
   --sdDeepRefFontFamily: Arial;
-  --sdDeepRefFontWeight: 500;
+  --sdDeepRefFontWeight: 800;
   --sdDeepRefLineHeight: 1.25;
   --sdDeepRefFontSize: 26px;
   --sdDeepRefLetterSpacing: 0;
   --sdDeepRefParagraphSpacing: 0;
   --sdDeepRefParagraphIndent: 0;
   --sdDeepRefTextDecoration: none;
-  --sdDeepRefTextCase: none;`,
+  --sdDeepRefTextCase: none;
+  --sdDeepRefFontStyle: italic;`,
     );
   });
 });

--- a/test/integration/object-value-references.test.ts
+++ b/test/integration/object-value-references.test.ts
@@ -45,9 +45,9 @@ describe('typography references', () => {
     const file = await promises.readFile(outputFilePath, 'utf-8');
     expect(file).to.include(
       `
-  --sdBefore: 700 36px/1 'Aria Sans';
-  --sdFontHeadingXxl: 700 36px/1 'Aria Sans';
-  --sdAfter: 700 36px/1 'Aria Sans';`,
+  --sdBefore: 400 italic 36px/1 'Aria Sans';
+  --sdFontHeadingXxl: 400 italic 36px/1 'Aria Sans';
+  --sdAfter: 400 italic 36px/1 'Aria Sans';`,
     );
   });
 

--- a/test/integration/tokens/expand-composition.tokens.json
+++ b/test/integration/tokens/expand-composition.tokens.json
@@ -32,7 +32,7 @@
   "typography": {
     "value": {
       "fontFamily": "Arial",
-      "fontWeight": "500",
+      "fontWeight": "{fontWeightRef}",
       "lineHeight": "1.25",
       "fontSize": "26",
       "letterSpacing": "0",
@@ -42,6 +42,10 @@
       "textCase": "none"
     },
     "type": "typography"
+  },
+  "fontWeightRef": {
+    "value": "ExtraBold italic",
+    "type": "fontWeights"
   },
   "border": {
     "value": {

--- a/test/integration/tokens/object-value-references.tokens.json
+++ b/test/integration/tokens/object-value-references.tokens.json
@@ -8,7 +8,7 @@
       "xxl": {
         "value": {
           "fontFamily": "Aria Sans",
-          "fontWeight": "bold",
+          "fontWeight": "{fontWeightRef}",
           "lineHeight": "1",
           "fontSize": "36",
           "letterSpacing": "1",
@@ -38,6 +38,10 @@
   },
   "shadowRef": {
     "value": "{shadow}"
+  },
+  "fontWeightRef": {
+    "value": "Regular Italic",
+    "type": "fontWeights"
   },
   "border": {
     "value": {

--- a/test/spec/checkAndEvaluateMath.spec.ts
+++ b/test/spec/checkAndEvaluateMath.spec.ts
@@ -56,4 +56,10 @@ describe('check and evaluate math', () => {
     expect(checkAndEvaluateMath('min(10, 24, 5, 12, 6) 8 * 14px')).to.equal('5 112px');
     expect(checkAndEvaluateMath('ceil(roundTo(16/1.2,0)/2)*2')).to.equal('14');
   });
+
+  it('does not unnecessarily remove wrapped quotes around font-family values', () => {
+    expect(checkAndEvaluateMath(`800 italic 16px/1 'Arial Black'`)).to.equal(
+      `800 italic 16px/1 'Arial Black'`,
+    );
+  });
 });

--- a/test/spec/css/transformTypographyForCSS.spec.ts
+++ b/test/spec/css/transformTypographyForCSS.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import {
   transformTypographyForCSS,
-  hasWhiteSpace,
   isCommaSeparated,
 } from '../../../src/css/transformTypography.js';
 import { runTransformSuite } from '../../suites/transform-suite.spec.js';
@@ -68,5 +67,24 @@ describe('transform typography', () => {
         lineHeight: '1.5',
       }),
     ).to.equal('300 20px/1.5 sans-serif');
+  });
+
+  it('includes fontStyle if included in the fontWeight', () => {
+    expect(
+      transformTypographyForCSS({
+        fontWeight: 'light Italic',
+        fontSize: '20',
+        lineHeight: '1.5',
+      }),
+    ).to.equal('300 italic 20px/1.5 sans-serif');
+
+    expect(
+      transformTypographyForCSS({
+        fontWeight: 'light',
+        fontSize: '20',
+        lineHeight: '1.5',
+        fontStyle: 'italic',
+      }),
+    ).to.equal('300 italic 20px/1.5 sans-serif');
   });
 });

--- a/test/spec/parsers/add-font-styles.spec.ts
+++ b/test/spec/parsers/add-font-styles.spec.ts
@@ -21,6 +21,16 @@ const tokensInput = {
     },
     type: 'typography',
   },
+  fwRef: {
+    value: 'SemiBold Italic',
+    type: 'fontWeights',
+  },
+  usesFwRef: {
+    value: {
+      fontWeight: '{fwRef}',
+    },
+    type: 'typography',
+  },
   ref: {
     value: '{italic}',
     type: 'typography',
@@ -49,11 +59,22 @@ const tokensOutput = {
     },
     type: 'typography',
   },
-  ref: {
+  fwRef: {
+    value: 'SemiBold Italic',
+    type: 'fontWeights',
+  },
+  // since we are referencing a fontWeights token that has fontStyle,
+  // we can resolve the reference and create the fontStyle prop
+  usesFwRef: {
     value: {
-      fontWeight: 'Bold',
+      fontWeight: 'SemiBold',
       fontStyle: 'italic',
     },
+    type: 'typography',
+  },
+  // Keep full typo reference "as is", the referred token will be transformed as needed
+  ref: {
+    value: '{italic}',
     type: 'typography',
   },
 };

--- a/test/spec/parsers/add-font-styles.spec.ts
+++ b/test/spec/parsers/add-font-styles.spec.ts
@@ -3,46 +3,63 @@ import { DeepKeyTokenMap } from '@tokens-studio/types';
 import { addFontStyles } from '../../../src/parsers/add-font-styles.js';
 
 const tokensInput = {
-  foo: {
+  italic: {
     value: {
-      fontFamily: 'Arial',
       fontWeight: 'Bold Italic',
-      lineHeight: '1.25',
-      fontSize: '26',
+    },
+    type: 'typography',
+  },
+  normal: {
+    value: {
+      fontWeight: 'Bold Normal',
+    },
+    type: 'typography',
+  },
+  oblique: {
+    value: {
+      fontWeight: 'Bold Oblique',
     },
     type: 'typography',
   },
   ref: {
-    value: '{foo}',
+    value: '{italic}',
     type: 'typography',
   },
 };
 
 const tokensOutput = {
-  foo: {
+  italic: {
     value: {
-      fontFamily: 'Arial',
       fontWeight: 'Bold',
       fontStyle: 'italic',
-      lineHeight: '1.25',
-      fontSize: '26',
+    },
+    type: 'typography',
+  },
+  normal: {
+    value: {
+      fontWeight: 'Bold',
+      fontStyle: 'normal',
+    },
+    type: 'typography',
+  },
+  oblique: {
+    value: {
+      fontWeight: 'Bold',
+      fontStyle: 'oblique',
     },
     type: 'typography',
   },
   ref: {
     value: {
-      fontFamily: 'Arial',
       fontWeight: 'Bold',
       fontStyle: 'italic',
-      lineHeight: '1.25',
-      fontSize: '26',
     },
     type: 'typography',
   },
 };
 
 describe('add font style', () => {
-  it.only(`should expand composition tokens by default`, () => {
+  it(`should expand composition tokens by default`, () => {
     expect(addFontStyles(tokensInput as DeepKeyTokenMap<false>)).to.eql(tokensOutput);
   });
 });

--- a/test/spec/parsers/add-font-styles.spec.ts
+++ b/test/spec/parsers/add-font-styles.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from '@esm-bundle/chai';
+import { DeepKeyTokenMap } from '@tokens-studio/types';
+import { addFontStyles } from '../../../src/parsers/add-font-styles.js';
+
+const tokensInput = {
+  foo: {
+    value: {
+      fontFamily: 'Arial',
+      fontWeight: 'Bold Italic',
+      lineHeight: '1.25',
+      fontSize: '26',
+    },
+    type: 'typography',
+  },
+  ref: {
+    value: '{foo}',
+    type: 'typography',
+  },
+};
+
+const tokensOutput = {
+  foo: {
+    value: {
+      fontFamily: 'Arial',
+      fontWeight: 'Bold',
+      fontStyle: 'italic',
+      lineHeight: '1.25',
+      fontSize: '26',
+    },
+    type: 'typography',
+  },
+  ref: {
+    value: {
+      fontFamily: 'Arial',
+      fontWeight: 'Bold',
+      fontStyle: 'italic',
+      lineHeight: '1.25',
+      fontSize: '26',
+    },
+    type: 'typography',
+  },
+};
+
+describe('add font style', () => {
+  it.only(`should expand composition tokens by default`, () => {
+    expect(addFontStyles(tokensInput as DeepKeyTokenMap<false>)).to.eql(tokensOutput);
+  });
+});

--- a/test/spec/parsers/add-font-styles.spec.ts
+++ b/test/spec/parsers/add-font-styles.spec.ts
@@ -83,4 +83,17 @@ describe('add font style', () => {
   it(`should expand composition tokens by default`, () => {
     expect(addFontStyles(tokensInput as DeepKeyTokenMap<false>)).to.eql(tokensOutput);
   });
+
+  it(`should ignore broken fontWeight reference`, () => {
+    const inputTokens = {
+      usesFwRef: {
+        value: {
+          fontWeight: '{fwRef}',
+        },
+        type: 'typography',
+      },
+    };
+
+    expect(addFontStyles(inputTokens as DeepKeyTokenMap<false>)).to.eql(inputTokens);
+  });
 });

--- a/test/spec/transformFontWeights.spec.ts
+++ b/test/spec/transformFontWeights.spec.ts
@@ -19,4 +19,9 @@ describe('transform dimension', () => {
   it('supports case-insensitive input', () => {
     expect(transformFontWeights('Light')).to.equal(300);
   });
+
+  it('supports fontWeights with fontStyles inside of them', () => {
+    expect(transformFontWeights('Light normal')).to.equal(`300 normal`);
+    expect(transformFontWeights('ExtraBold Italic')).to.equal(`800 italic`);
+  });
 });


### PR DESCRIPTION
**Summary:** 
This adds a parser function to add a `fontStyle` to typography tokens based on the `fontWeight` value.

**Problem:**
When working with `tokens-studio`, it's kind of difficult to work with `fontWeights` and certainly when combined with something like `italics`. 

**Proposed solution:**
I was wondering if it would be an idea to solve this in the custom parser. I'm thinking you could strip out "italic" from the `fontWeight` and add it to a typography token as a separate property. After which, it could be expanded if you'd like that.

So
```json
"my-typography-token": {
  "value": {
    "fontFamily": "Roboto",
    "fontWeight": "ExtraBold Italic",
    "lineHeight": "16px",
    "fontSize": "12px"
  },
  "type": "typography"
}
```
would be (after parsing)
```json
"my-typography-token": {
  "value": {
    "fontFamily": "Roboto",
    "fontWeight": "ExtraBold",
    "lineHeight": "16px",
    "fontSize": "12px",
    "fontStyle": "italic"
  },
  "type": "typography"
}
```

Also: the spec mentions [it will probably document a fontStyle type](https://design-tokens.github.io/community-group/format/#additional-types)

**Note:** 
This is a work in progress. I'm sharing what I have right now, but I don't know any typescript so I'm hoping you can pick this up to finish it. 😄 