### PR TITLE
128: Save expanded tokens to separate property

### DIFF
--- a/src/parsers/expand-composites.ts
+++ b/src/parsers/expand-composites.ts
@@ -121,7 +121,7 @@ function recurse(
             }
             token.value = ref as SingleToken<false>['value'];
           }
-          slice[key] = expandToken(token, expandType === 'shadow');
+          slice[key + '-part'] = expandToken(token, expandType === 'shadow');
         }
       }
     } else if (typeof token === 'object') {


### PR DESCRIPTION
Will resolve #128

What do you think of this solution?
We move over the expanded tokens to a separate property, keeping the original composite token, which is output as before.
If you agree, a simple name transformer can be added to remove the added text from the name.