### PR TITLE
Fix recurse in add-font-styles

### DIFF
--- a/.changeset/wild-trainers-laugh.md
+++ b/.changeset/wild-trainers-laugh.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Add alwaysAddFontStyle to recursive function parameters.

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -51,7 +51,7 @@ function recurse(
         tokenValue.fontStyle = 'normal';
       }
     } else if (typeof token === 'object') {
-      recurse(token as unknown as DeepKeyTokenMap<false>, boundGetRef);
+      recurse(token as unknown as DeepKeyTokenMap<false>, boundGetRef, alwaysAddFontStyle);
     }
   }
 }


### PR DESCRIPTION
The `alwaysAddFontStyle` isn't re-passed in the `recurse` function.