### PR TITLE
Fix add-font-styles with italic weight that don't explicitly state they are regular

### DIFF
--- a/.changeset/unlucky-zebras-type.md
+++ b/.changeset/unlucky-zebras-type.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Handle fonts that put only fontStyle inside fontWeight properly e.g. "Italic", which should resolve to weight "Regular" and style "Italic".

--- a/src/parsers/add-font-styles.ts
+++ b/src/parsers/add-font-styles.ts
@@ -3,7 +3,7 @@ import { DeepKeyTokenMap, SingleToken, TokenTypographyValue } from '@tokens-stud
 import getReferences from 'style-dictionary/lib/utils/references/getReferences.js';
 // @ts-expect-error no type exported for this function
 import usesReference from 'style-dictionary/lib/utils/references/usesReference.js';
-import { fontWeightReg } from '../transformFontWeights.js';
+import { fontWeightReg, fontStyles } from '../transformFontWeights.js';
 import { TransformOptions } from '../TransformOptions.js';
 
 function recurse(
@@ -44,6 +44,13 @@ function recurse(
         if (fontStyleMatch?.groups?.weight && fontStyleMatch.groups.style) {
           tokenValue.fontStyle = fontStyleMatch.groups.style.toLowerCase();
           tokenValue.fontWeight = fontStyleMatch?.groups?.weight;
+        }
+
+        // Roboto Regular Italic might have only: `fontWeight: 'Italic'`
+        // which means that the weight is Regular and the style is Italic
+        if (fontStyles.includes(fontWeight.toLowerCase())) {
+          tokenValue.fontStyle = fontWeight.toLowerCase();
+          tokenValue.fontWeight = 'Regular';
         }
       }
 

--- a/src/transformFontWeights.ts
+++ b/src/transformFontWeights.ts
@@ -27,7 +27,11 @@ export const fontWeightMap = {
   ultra: 1000,
 };
 
-export const fontWeightReg = /(?<weight>.+?)\s?(?<style>italic|oblique|normal)?$/i;
+export const fontStyles = ['italic', 'oblique', 'normal'];
+export const fontWeightReg = new RegExp(
+  `(?<weight>.+?)\\s?(?<style>${fontStyles.join('|')})?$`,
+  'i',
+);
 
 /**
  * Helper: Transforms fontweight keynames to fontweight numbers (100, 200, 300 ... 900)

--- a/test/spec/parsers/add-font-styles.spec.ts
+++ b/test/spec/parsers/add-font-styles.spec.ts
@@ -9,6 +9,12 @@ const tokensInput = {
     },
     type: 'typography',
   },
+  italicOnly: {
+    value: {
+      fontWeight: 'Italic',
+    },
+    type: 'typography',
+  },
   normal: {
     value: {
       fontWeight: 'Bold Normal',
@@ -41,6 +47,13 @@ const tokensOutput = {
   italic: {
     value: {
       fontWeight: 'Bold',
+      fontStyle: 'italic',
+    },
+    type: 'typography',
+  },
+  italicOnly: {
+    value: {
+      fontWeight: 'Regular',
       fontStyle: 'italic',
     },
     type: 'typography',


### PR DESCRIPTION
Some fonts (such as Roboto) don't explicitly name their regular italic weight `Regular Italic`. (It's just named `Italic` instead of `Regular Italic`.)

Not sure how you'd like to handle this case, but I've already added a test case.