### PR TITLE
Fix test of check-and-evaluate-math

### DIFF
--- a/.changeset/sharp-lamps-smash.md
+++ b/.changeset/sharp-lamps-smash.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Slightly adjust how math evaluation is done on non-numeric string and boolean values, so as to not remove quotes inside strings.

--- a/src/checkAndEvaluateMath.ts
+++ b/src/checkAndEvaluateMath.ts
@@ -93,12 +93,14 @@ function parseAndReduce(expr: string): string | boolean | number {
   let evaluated;
   try {
     evaluated = parser.evaluate(unitlessExpr);
+    if (typeof evaluated !== 'number') {
+      return expr;
+    }
   } catch (ex) {
     return expr;
   }
 
-  const formatted =
-    typeof evaluated === 'number' ? Number.parseFloat(evaluated.toFixed(3)) : evaluated;
+  const formatted = Number.parseFloat(evaluated.toFixed(3));
   // Put back the px unit if needed and if reduced doesn't come with one
   const formattedUnit = unit ?? (hasPx ? 'px' : '');
 
@@ -109,7 +111,7 @@ function parseAndReduce(expr: string): string | boolean | number {
 export function checkAndEvaluateMath(
   expr: string | number | boolean | undefined,
 ): string | number | boolean | undefined {
-  if (expr === undefined) {
+  if (expr === undefined || typeof expr === 'boolean') {
     return expr;
   }
   const exprs = splitMultiIntoSingleValues(`${expr}`);

--- a/test/spec/checkAndEvaluateMath.spec.ts
+++ b/test/spec/checkAndEvaluateMath.spec.ts
@@ -65,7 +65,7 @@ describe('check and evaluate math', () => {
   });
 
   it('supports values that contain spaces and strings, e.g. a date format', () => {
-    expect(checkAndEvaluateMath(`dd/MM/yyyy 'om' HH:mm`)).to.equal(`dd/MM/yyyy om HH:mm`);
+    expect(checkAndEvaluateMath(`dd/MM/yyyy 'om' HH:mm`)).to.equal(`dd/MM/yyyy 'om' HH:mm`);
   });
 
   it('supports boolean values', () => {


### PR DESCRIPTION
This test shouldn't remove the quotes of the nested string I think?