### PR TITLE
resolve issue 222 (Suisse Int'l font family transform issue / special character transform)

### DIFF
--- a/.changeset/slow-wolves-notice.md
+++ b/.changeset/slow-wolves-notice.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Refined CSS font name processing: Enhanced escapeApostrophes for accurate apostrophe handling in font names. Updated quoteWrapWhitespacedFont for smart quoting and escaping in multi-word fonts. Ensures better CSS font family compatibility.

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -16,8 +16,8 @@ export function isCommaSeparated(value: string): boolean {
   return value.includes(',');
 }
 
-export function escapeApostrophes(str: string) {
-  return str.replace(/'/g, "\\'");
+export function escapeApostrophes(value: string) {
+  return value.replace(/'/g, "\\'");
 }
 
 function quoteWrapWhitespacedFont(fontString: string) {

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -16,7 +16,7 @@ export function isCommaSeparated(value: string): boolean {
   return value.includes(',');
 }
 
-export function escapeApostrophes(value: string) {
+export function escapeApostrophes(value: string): string {
   return value.replace(/'/g, "\\'");
 }
 

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -16,8 +16,13 @@ export function isCommaSeparated(value: string): boolean {
   return value.includes(',');
 }
 
+export function escapeApostrophes(str: string) {
+  return str.replace(/'/g, "\\'");
+}
+
 function quoteWrapWhitespacedFont(fontString: string) {
-  return hasWhiteSpace(fontString) && !isAlreadyQuoted(fontString) ? `'${fontString}'` : fontString;
+  let escapedFontString = escapeApostrophes(fontString);
+  return hasWhiteSpace(escapedFontString) && !isAlreadyQuoted(escapedFontString) ? `'${escapedFontString}'` : escapedFontString;
 }
 
 export function processFontFamily(fontFamily: string | undefined) {

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -21,8 +21,12 @@ export function escapeApostrophes(value: string): string {
 }
 
 function quoteWrapWhitespacedFont(fontString: string) {
-  let escapedFontString = escapeApostrophes(fontString);
-  return hasWhiteSpace(escapedFontString) && !isAlreadyQuoted(escapedFontString) ? `'${escapedFontString}'` : escapedFontString;
+  let fontName = fontString.trim();
+  const isQuoted = isAlreadyQuoted(fontName);
+  if (!isQuoted) {
+    fontName = escapeApostrophes(fontName);
+  }
+  return hasWhiteSpace(fontName) && !isQuoted ? `'${fontName}'` : fontName;
 }
 
 export function processFontFamily(fontFamily: string | undefined) {

--- a/test/integration/sd-transforms.test.ts
+++ b/test/integration/sd-transforms.test.ts
@@ -71,7 +71,7 @@ describe('sd-transforms smoke tests', () => {
   --sdFontWeightsBodyRegular: 400;
   --sdFontSizesH6: 16px;
   --sdFontSizesBody: 16px;
-  --sdHeading6: 700 16px/1 Arial;
+  --sdHeading6: 700 16px/1 'Arial Black', 'Suisse Int\\'l', sans-serif;
   --sdShadowBlur: 10px;
   --sdShadow: inset 0 4px 10px 0 rgba(0,0,0,0.4);
   --sdBorderWidth: 5px;
@@ -115,7 +115,7 @@ describe('sd-transforms smoke tests', () => {
   --sd-font-weights-body-regular: 400;
   --sd-font-sizes-h6: 16px;
   --sd-font-sizes-body: 16px;
-  --sd-heading-6: 700 16px/1 Arial;
+  --sd-heading-6: 700 16px/1 'Arial Black', 'Suisse Int\\'l', sans-serif;
   --sd-shadow-blur: 10px;
   --sd-shadow: inset 0 4px 10px 0 rgba(0,0,0,0.4);
   --sd-border-width: 5px;

--- a/test/integration/tokens/sd-transforms.tokens.json
+++ b/test/integration/tokens/sd-transforms.tokens.json
@@ -146,7 +146,7 @@
     "value": {
       "fontSize": "{fontSizes.h6}",
       "fontWeight": "700",
-      "fontFamily": "Arial",
+      "fontFamily": "Arial Black, Suisse Int'l, sans-serif",
       "lineHeight": "1"
     },
     "type": "typography"

--- a/test/spec/css/transformFontFamilies.spec.ts
+++ b/test/spec/css/transformFontFamilies.spec.ts
@@ -9,9 +9,9 @@ describe('process font family', () => {
     expect(processFontFamily('Arial Black, Times New Roman, Foo, sans-serif')).to.equal(
       `'Arial Black', 'Times New Roman', Foo, sans-serif`,
     );
-    expect(processFontFamily(`'Arial Black', Times New Roman, Foo, sans-serif`)).to.equal(
-      `'Arial Black', 'Times New Roman', Foo, sans-serif`,
-    );
+    expect(
+      processFontFamily(`'Arial Black', Times New Roman, Suisse Int'l, Foo, sans-serif`),
+    ).to.equal(`'Arial Black', 'Times New Roman', 'Suisse Int\\'l', Foo, sans-serif`);
   });
 });
 

--- a/test/spec/css/transformFontFamilies.spec.ts
+++ b/test/spec/css/transformFontFamilies.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { processFontFamily } from '../../../src/css/transformTypography.js';
+import { processFontFamily, escapeApostrophes } from '../../../src/css/transformTypography.js';
 
 describe('process font family', () => {
   it('transforms font-family to have single quotes around multi-word font-families', () => {
@@ -12,5 +12,13 @@ describe('process font family', () => {
     expect(processFontFamily(`'Arial Black', Times New Roman, Foo, sans-serif`)).to.equal(
       `'Arial Black', 'Times New Roman', Foo, sans-serif`,
     );
+  });
+});
+
+describe('escape apostrophes', () => {
+  it('should escape single apostrophes in strings', () => {
+    expect(escapeApostrophes("Suisse Int'l")).to.equal("Suisse Int\\'l");
+    expect(escapeApostrophes("Font's Example")).to.equal("Font\\'s Example");
+    expect(escapeApostrophes('NoEscape')).to.equal('NoEscape');
   });
 });


### PR DESCRIPTION
fixes https://github.com/tokens-studio/sd-transforms/issues/222

Escape any occurences of ' automatically in the quoteWrapWhitespacedFont to resolve the issue with special character `.

**escapeApostrophes** is a new function that takes a string and replaces every apostrophe with an escaped apostrophe. It uses the replace method with a regular expression /'/g that matches all occurrences of an apostrophe and replaces them with \' (the double backslash is needed because backslash is an escape character in JavaScript strings).

In the quoteWrapWhitespacedFont (exisiting function), the input string is first passed to escapeApostrophes to ensure all apostrophes are properly escaped. Then, the rest of the function proceeds as before, but uses the escaped string for the checks and final return value.

This should resolve the issue with breaking CSS when the string contains apostrophes.