### PR TITLE
replace escapeApostrophes with specialCharacterFontStringFormatter (Transforms 'Suisse Int'l' into 'Suisse intl')

### DIFF
--- a/.changeset/bright-sloths-search.md
+++ b/.changeset/bright-sloths-search.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Replaced escapeApostrophes with specialCharacterFontStringFormatter to specifically address the formatting of the 'Suisse Int'l' font family. This targeted update ensures correct handling of this unique font family name, streamlining the CSS typography processing for more consistent and accurate rendering.

--- a/src/css/transformTypography.ts
+++ b/src/css/transformTypography.ts
@@ -16,17 +16,16 @@ export function isCommaSeparated(value: string): boolean {
   return value.includes(',');
 }
 
-export function escapeApostrophes(value: string): string {
-  return value.replace(/'/g, "\\'");
+export function specialCharacterFontStringFormatter(value: string): string {
+  if (value === "Suisse Int'l") {
+    return 'Suisse intl';
+  }
+  return value;
 }
 
 function quoteWrapWhitespacedFont(fontString: string) {
-  let fontName = fontString.trim();
-  const isQuoted = isAlreadyQuoted(fontName);
-  if (!isQuoted) {
-    fontName = escapeApostrophes(fontName);
-  }
-  return hasWhiteSpace(fontName) && !isQuoted ? `'${fontName}'` : fontName;
+  fontString = specialCharacterFontStringFormatter(fontString);
+  return hasWhiteSpace(fontString) && !isAlreadyQuoted(fontString) ? `'${fontString}'` : fontString;
 }
 
 export function processFontFamily(fontFamily: string | undefined) {

--- a/test/integration/sd-transforms.test.ts
+++ b/test/integration/sd-transforms.test.ts
@@ -71,7 +71,7 @@ describe('sd-transforms smoke tests', () => {
   --sdFontWeightsBodyRegular: 400;
   --sdFontSizesH6: 16px;
   --sdFontSizesBody: 16px;
-  --sdHeading6: 700 16px/1 'Arial Black', 'Suisse Int\\'l', sans-serif;
+  --sdHeading6: 700 16px/1 'Arial Black', 'Suisse intl', sans-serif;
   --sdShadowBlur: 10px;
   --sdShadow: inset 0 4px 10px 0 rgba(0,0,0,0.4);
   --sdBorderWidth: 5px;
@@ -115,7 +115,7 @@ describe('sd-transforms smoke tests', () => {
   --sd-font-weights-body-regular: 400;
   --sd-font-sizes-h6: 16px;
   --sd-font-sizes-body: 16px;
-  --sd-heading-6: 700 16px/1 'Arial Black', 'Suisse Int\\'l', sans-serif;
+  --sd-heading-6: 700 16px/1 'Arial Black', 'Suisse intl', sans-serif;
   --sd-shadow-blur: 10px;
   --sd-shadow: inset 0 4px 10px 0 rgba(0,0,0,0.4);
   --sd-border-width: 5px;

--- a/test/spec/css/transformFontFamilies.spec.ts
+++ b/test/spec/css/transformFontFamilies.spec.ts
@@ -12,10 +12,9 @@ describe('process font family', () => {
     expect(processFontFamily('Arial Black, Times New Roman, Foo, sans-serif')).to.equal(
       `'Arial Black', 'Times New Roman', Foo, sans-serif`,
     );
-    expect(processFontFamily(`'Arial Black', Times New Roman, Foo, sans-serif`)).to.equal(
-      `'Arial Black', 'Times New Roman', Foo, sans-serif`,
-    );
-    expect(processFontFamily("Suisse Int'l")).to.equal("'Suisse intl'");
+    expect(
+      processFontFamily(`'Arial Black', Times New Roman, Suisse Int'l, Foo, sans-serif`),
+    ).to.equal(`'Arial Black', 'Times New Roman', 'Suisse intl', Foo, sans-serif`);
   });
 });
 

--- a/test/spec/css/transformFontFamilies.spec.ts
+++ b/test/spec/css/transformFontFamilies.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { processFontFamily, escapeApostrophes } from '../../../src/css/transformTypography.js';
+import {
+  processFontFamily,
+  specialCharacterFontStringFormatter,
+} from '../../../src/css/transformTypography.js';
 
 describe('process font family', () => {
   it('transforms font-family to have single quotes around multi-word font-families', () => {
@@ -9,16 +12,15 @@ describe('process font family', () => {
     expect(processFontFamily('Arial Black, Times New Roman, Foo, sans-serif')).to.equal(
       `'Arial Black', 'Times New Roman', Foo, sans-serif`,
     );
-    expect(
-      processFontFamily(`'Arial Black', Times New Roman, Suisse Int'l, Foo, sans-serif`),
-    ).to.equal(`'Arial Black', 'Times New Roman', 'Suisse Int\\'l', Foo, sans-serif`);
+    expect(processFontFamily(`'Arial Black', Times New Roman, Foo, sans-serif`)).to.equal(
+      `'Arial Black', 'Times New Roman', Foo, sans-serif`,
+    );
+    expect(processFontFamily("Suisse Int'l")).to.equal("'Suisse intl'");
   });
 });
 
-describe('escape apostrophes', () => {
-  it('should escape single apostrophes in strings', () => {
-    expect(escapeApostrophes("Suisse Int'l")).to.equal("Suisse Int\\'l");
-    expect(escapeApostrophes("Font's Example")).to.equal("Font\\'s Example");
-    expect(escapeApostrophes('NoEscape')).to.equal('NoEscape');
+describe('format special character font strings', () => {
+  it("should format from Suisse Int'l to Suisse intl", () => {
+    expect(specialCharacterFontStringFormatter("Suisse Int'l")).to.equal('Suisse intl');
   });
 });


### PR DESCRIPTION
In this update, i have replaced the [escapeApostrophes ](https://github.com/tokens-studio/sd-transforms/pull/223/files) function with specialCharacterFontStringFormatter. The previous escapeApostrophes function was intended to escape apostrophes in font family names, but it led to invalid CSS formatting in certain cases. An example of this issue was evident with the 'Suisse Int'l' font family, where the output `--sdTypographyMobileBody: 400 14px/20 'Suisse Int\'l';` was not a valid CSS format.

The [escapeApostrophes ](https://github.com/tokens-studio/sd-transforms/pull/223/files) approach incorrectly added a backslash before the apostrophe, which is not a standard or recognized escape sequence in CSS font family names. This resulted in malformed CSS that could cause rendering issues or be ignored by the browser.

The new specialCharacterFontStringFormatter function directly addresses this problem by specifically targeting and correctly formatting the `'Suisse Int'l'` font family name. Instead of attempting a broad and potentially erroneous escape of apostrophes, it transforms `'Suisse Int'l' `into `'Suisse intl'`, a format that is valid and compatible with CSS standards. This targeted approach provides a more robust and accurate solution for handling special cases in the CSS typography processing.

If you need more special caces for special character font families you can add it to specialCharacterFontStringFormatter (that's why i named it like that) and just add test for it. It should not be that many font families that have special characters like this.