### PR TITLE
Add "book" to font weights

### DIFF
--- a/src/transformFontWeights.ts
+++ b/src/transformFontWeights.ts
@@ -10,6 +10,7 @@ export const fontWeightMap = {
   normal: 400,
   regular: 400,
   buch: 400,
+  book: 400,
   medium: 500,
   kraeftig: 500,
   kräftig: 500,


### PR DESCRIPTION
We use the Sharp Sans font in our project, where we use Tokens Studio and Figma: https://sharptype.co/typefaces/sharp-sans/#specimen

Sharp Sans defines the 400 font-weight as `Book`, so that's what Figma uses.

Currently, `sd-transform` transforms other font weights to numbers, but `Book` stays as is, which is not right.