### PR TITLE
chore: small fix for platform config usage

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -73,7 +73,7 @@ export async function register(sd: typeof StyleDictionary, transformOpts?: Trans
     type: 'value',
     transitive: true,
     filter: token => ['string', 'object'].includes(typeof (token.$value ?? token.value)),
-    transform: (token, config) => checkAndEvaluateMath(token, config.options?.mathFractionDigits),
+    transform: (token, platformCfg) => checkAndEvaluateMath(token, platformCfg.mathFractionDigits),
   });
 
   sd.registerTransform({

--- a/test/spec/checkAndEvaluateMath.spec.ts
+++ b/test/spec/checkAndEvaluateMath.spec.ts
@@ -127,9 +127,7 @@ describe('check and evaluate math', () => {
       platforms: {
         css: {
           transformGroup: 'tokens-studio',
-          options: {
-            mathFractionDigits: 3,
-          },
+          mathFractionDigits: 3,
           files: [
             {
               format: 'css/variables',


### PR DESCRIPTION
fixes some sloppiness I introduced here: https://github.com/tokens-studio/sd-transforms/pull/290

I wouldn't mind encapsulating platform config options inside an `options` property like we do for format-level options, it would be a bit more consistent.. But currently style-dictionary also doesn't do this for the platform config option "basePxFontSize" so doing it now would be inconsistent as well.

I think we should pull transform options passed through platform config into an "options" object though in the future but this would a small breaking change, so it will be style-dictionary v5. too bad I missed this for v4.