### PR TITLE
fix: evaluate math expressions with units

### DIFF
--- a/.changeset/brave-timers-burn.md
+++ b/.changeset/brave-timers-burn.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+fix: evaluate math expressions with units

--- a/test/spec/checkAndEvaluateMath.spec.ts
+++ b/test/spec/checkAndEvaluateMath.spec.ts
@@ -86,6 +86,27 @@ describe('check and evaluate math', () => {
     ).to.equal(14);
   });
 
+  it('supports expr-eval expressions with units', () => {
+    expect(checkAndEvaluateMath({ value: 'roundTo(4px / 7, 1)', type: 'dimension' })).to.equal(
+      '0.6px',
+    );
+    expect(
+      checkAndEvaluateMath({ value: '8 * 14px roundTo(4 / 7px, 1)', type: 'dimension' }),
+    ).to.equal('112px 0.6px');
+    expect(
+      checkAndEvaluateMath({ value: 'roundTo(4px / 7px, 1) 8 * 14px', type: 'dimension' }),
+    ).to.equal('0.6px 112px');
+    expect(
+      checkAndEvaluateMath({
+        value: 'min(10px, 24px, 5px, 12px, 6px) 8 * 14px',
+        type: 'dimension',
+      }),
+    ).to.equal('5px 112px');
+    expect(
+      checkAndEvaluateMath({ value: 'ceil(roundTo(16px/1.2,0)/2)*2', type: 'dimension' }),
+    ).to.equal('14px');
+  });
+
   it('should support expr eval expressions in combination with regular math', () => {
     expect(checkAndEvaluateMath({ value: 'roundTo(4 / 7, 1) * 24', type: 'dimension' })).to.equal(
       14.4,


### PR DESCRIPTION
A recent PR (https://github.com/tokens-studio/sd-transforms/pull/49) broke the ability to evaluate math expressions **with** units.

```
roundTo(30px/5)
```

This PR changes the order of operations, so that both `eval-expr` and `postcss-calc-ast-parser` are applied to the expression without any units.
Furthermore I added some additional checks to increase the speed of the evaluation function.