### PR TITLE
chore: add TransformOptions type to `init` in integration tests

### DIFF
--- a/test/integration/cross-file-refs.test.ts
+++ b/test/integration/cross-file-refs.test.ts
@@ -34,7 +34,6 @@ describe('cross file references', () => {
     cleanup(dict);
     dict = await init(cfg, {
       withSDBuiltins: false,
-      expand: { typography: true },
     });
   });
 

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -1,8 +1,9 @@
 import type { Config } from 'style-dictionary/types';
 import StyleDictionary from 'style-dictionary';
+import type { TransformOptions } from '../../src/TransformOptions.js';
 import { register } from '../../src/register.js';
 
-export async function init(cfg: Config, transformOpts = {}) {
+export async function init(cfg: Config, transformOpts: TransformOptions = {}) {
   register(StyleDictionary, transformOpts);
   const dict = new StyleDictionary({
     ...cfg,


### PR DESCRIPTION
While exploring some of the transforms and their associated tests, I noticed the `init` function used to initialize `style-dictionary` (i.e., register `sd-transforms` and `dict.buildAllPlatforms()`) accepts an untyped function argument `transformOpts`.

This PR associates the `TransformOptions` type to this `transformOpts` argument.

In doing so, TypeScript began throwing an error within `cross-file-refs.test.ts` that the existing `expand` option passed to `init` isn't valid per the `TransformOptions` type. The tests pass regardless of whether `expand` is present or not in the provided options, which seems to indicate nothing consumes the property value. As such, I've removed `expand` from this test suite.