### PR TITLE
fix: supports `mathFractionDigits` option during `register`

### DIFF
--- a/.changeset/metal-pumas-float.md
+++ b/.changeset/metal-pumas-float.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Support configuring mathFractionDigits via register's TransformOptions

--- a/src/TransformOptions.ts
+++ b/src/TransformOptions.ts
@@ -10,5 +10,6 @@ export interface TransformOptions {
   withSDBuiltins?: boolean;
   alwaysAddFontStyle?: boolean;
   excludeParentKeys?: boolean;
+  mathFractionDigits?: number;
   ['ts/color/modifiers']?: ColorModifierOptions;
 }

--- a/src/checkAndEvaluateMath.ts
+++ b/src/checkAndEvaluateMath.ts
@@ -151,9 +151,13 @@ function parseAndReduce(expr: string, fractionDigits = defaultFractionDigits): s
   return result;
 }
 
+interface CheckAndEvaluateMathOptions {
+  fractionDigits?: number;
+}
+
 export function checkAndEvaluateMath(
   token: DesignToken,
-  fractionDigits?: number,
+  opts: CheckAndEvaluateMathOptions = {},
 ): DesignToken['value'] {
   const expr = token.$value ?? token.value;
   const type = token.$type ?? token.type;
@@ -167,7 +171,7 @@ export function checkAndEvaluateMath(
       return expr;
     }
     const exprs = splitMultiIntoSingleValues(expr);
-    const reducedExprs = exprs.map(_expr => parseAndReduce(_expr, fractionDigits));
+    const reducedExprs = exprs.map(_expr => parseAndReduce(_expr, opts.fractionDigits));
     if (reducedExprs.length === 1) {
       return reducedExprs[0];
     }

--- a/src/register.ts
+++ b/src/register.ts
@@ -73,7 +73,12 @@ export async function register(sd: typeof StyleDictionary, transformOpts?: Trans
     type: 'value',
     transitive: true,
     filter: token => ['string', 'object'].includes(typeof (token.$value ?? token.value)),
-    transform: (token, platformCfg) => checkAndEvaluateMath(token, platformCfg.mathFractionDigits),
+    transform: (token, platformCfg) => {
+      const opts = {
+        fractionDigits: transformOpts?.mathFractionDigits ?? platformCfg.mathFractionDigits,
+      };
+      return checkAndEvaluateMath(token, opts);
+    },
   });
 
   sd.registerTransform({

--- a/test/integration/cross-file-refs.test.ts
+++ b/test/integration/cross-file-refs.test.ts
@@ -34,7 +34,6 @@ describe('cross file references', () => {
     cleanup(dict);
     dict = await init(cfg, {
       withSDBuiltins: false,
-      expand: { typography: true },
     });
   });
 

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -1,8 +1,9 @@
 import type { Config } from 'style-dictionary/types';
 import StyleDictionary from 'style-dictionary';
 import { register } from '../../src/register.js';
+import { TransformOptions } from '../../src/TransformOptions.js';
 
-export async function init(cfg: Config, transformOpts = {}) {
+export async function init(cfg: Config, transformOpts: TransformOptions = {}) {
   register(StyleDictionary, transformOpts);
   const dict = new StyleDictionary({
     ...cfg,


### PR DESCRIPTION
_Follow-up to https://github.com/tokens-studio/sd-transforms/pull/290_

Currently, when configuring the optional `mathFractionDigits`, it must be done from within the `platform` config directly versus in the `TransformOptions` passed to `register` when registering the `sd-transforms` onto `StyleDictionary`.

Given the registering of transforms via `sd-transforms`' `register` function is specific to an individual `platform` (e.g., `css`), it would seem the `mathFractionDigits` option could be configured at the time of registering transforms, instead of as a property on the `style-dictionary` configuration itself.

### Changes

Now supports configuring `mathFractionDigits` via the transform options passed to the `register` function provided by `sd-transforms` instead of in the Style Dictionary `platforms` configuration.

This has the benefit of ensuring `mathFractionDigits` is properly typed as a first-class option within `TransformOptions`.

The existing configuration approach (i.e., relying on updating the Style Dictionary configuration) is still used as a fallback (non-breaking change), though perhaps this fallback config option is considered deprecated so a future release can align on a single mechanism for customizing this option.

### Examples

#### Current

```
/* Style Dictionary config */
{
  platforms: {
    css: {
      mathFractionDigits: 3
      ...
    }
    ...
  }
}
```

#### Proposed: With `register` options

```js
register(StyleDictionary, {
  platform: 'css',
  mathFractionDigits: 3,
});
```

No change needed to Style Dictionary config, and the `mathFractionDigits` is still specific the same platform that would have otherwise been modified in its `style-dictionary` configuration.