### PR TITLE
letterSpacing is no longer a dimension token (#316)

### DIFF
--- a/.changeset/smart-pianos-destroy.md
+++ b/.changeset/smart-pianos-destroy.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Addressed issue #316 about letterSpacing. LetterSpacing is no longer a dimension token. Also, the expand composition test token has been modify to test if the letterSpacing still works properly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export const expandTypesMap = {
     sizing: 'dimension',
     borderRadius: 'dimension',
     borderWidth: 'dimension',
-    letterSpacing: 'dimension',
     paragraphSpacing: 'dimension',
     paragraphIndent: 'dimension',
     text: 'content',

--- a/test/integration/expand-composition.test.ts
+++ b/test/integration/expand-composition.test.ts
@@ -73,6 +73,8 @@ describe('expand composition tokens', () => {
   --sdCompositionHeaderFontFamily: Roboto;
   --sdCompositionHeaderFontSize: 96px;
   --sdCompositionHeaderFontWeight: 700;
+  --sdCompositionHeaderLineHeight: 1.25;
+  --sdCompositionHeaderLetterSpacing: 1.25em;
   --sdTypography: italic 800 26px/1.25 Arial;
   --sdFontWeightRefWeight: 800;
   --sdFontWeightRefStyle: italic;
@@ -95,6 +97,8 @@ describe('expand composition tokens', () => {
   --sdCompositionHeaderFontFamily: Roboto;
   --sdCompositionHeaderFontSize: 96px;
   --sdCompositionHeaderFontWeight: 700;
+  --sdCompositionHeaderLineHeight: 1.25;
+  --sdCompositionHeaderLetterSpacing: 1.25em;
   --sdTypographyFontFamily: Arial;
   --sdTypographyFontWeight: 800;
   --sdTypographyLineHeight: 1.25;

--- a/test/integration/tokens/expand-composition.tokens.json
+++ b/test/integration/tokens/expand-composition.tokens.json
@@ -24,7 +24,9 @@
       "value": {
         "fontFamily": "{composition.fontFamily}",
         "fontSize": "96",
-        "fontWeight": "{composition.fontWeight}"
+        "fontWeight": "{composition.fontWeight}",
+        "lineHeight": "125%",
+        "letterSpacing": "125%"
       },
       "type": "composition"
     }


### PR DESCRIPTION
letterSpacing is no longer a dimension token. I updated one of the test tokens to see if letterSpacing still acts properly. The tests have all passed.