### PR TITLE
fixed multiple token dimension values(#320)

### DIFF
--- a/.changeset/brave-poets-rest.md
+++ b/.changeset/brave-poets-rest.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+Fix `ts/size/px` transform to handle multi-value token values such as `'button.padding': { value: '4 8' }`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "1.2.6",
+      "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",

--- a/test/spec/transformDimension.spec.ts
+++ b/test/spec/transformDimension.spec.ts
@@ -10,6 +10,10 @@ describe('transform dimension', () => {
     expect(transformDimension({ value: 4 })).to.equal('4px');
   });
 
+  it('supports multiple values', () => {
+    expect(transformDimension({ value: '4 8' })).to.equal('4px 8px');
+  });
+
   it('does not transform a dimension if it already is suffixed with "px"', () => {
     expect(transformDimension({ value: '4px' })).to.equal('4px');
   });
@@ -24,104 +28,261 @@ describe('transform dimension', () => {
   });
 
   describe('composite tokens', () => {
-    it('should add units to typography props', () => {
-      expect(
-        transformDimension({
-          type: 'typography',
-          value: {
-            fontSize: '4',
-            fontFamily: 'Arial',
-          },
-        }),
-      ).to.eql({ fontSize: '4px', fontFamily: 'Arial' });
-      expect(
-        transformDimension({
-          $type: 'typography',
-          $value: {
-            fontSize: '4',
-            fontFamily: 'Arial',
-          },
-        }),
-      ).to.eql({ fontSize: '4px', fontFamily: 'Arial' });
+    describe('typography', () => {
+      it('should add units to single-value fontSize with type', () => {
+        expect(
+          transformDimension({
+            type: 'typography',
+            value: {
+              fontSize: '4',
+              fontFamily: 'Arial',
+            },
+          }),
+        ).to.eql({ fontSize: '4px', fontFamily: 'Arial' });
+      });
+
+      it('should add units to single-value fontSize with $type', () => {
+        expect(
+          transformDimension({
+            $type: 'typography',
+            $value: {
+              fontSize: '4',
+              fontFamily: 'Arial',
+            },
+          }),
+        ).to.eql({ fontSize: '4px', fontFamily: 'Arial' });
+      });
+
+      it('should add units to multi-value fontSize with type', () => {
+        expect(
+          transformDimension({
+            type: 'typography',
+            value: {
+              fontSize: '4 8',
+              fontFamily: 'Arial',
+            },
+          }),
+        ).to.eql({ fontSize: '4px 8px', fontFamily: 'Arial' });
+      });
+
+      it('should add units to multi-value fontSize with $type', () => {
+        expect(
+          transformDimension({
+            $type: 'typography',
+            $value: {
+              fontSize: '4 8',
+              fontFamily: 'Arial',
+            },
+          }),
+        ).to.eql({ fontSize: '4px 8px', fontFamily: 'Arial' });
+      });
     });
 
-    it('should add units to shadow props', () => {
-      expect(
-        transformDimension({
-          type: 'shadow',
-          value: {
-            offsetX: '1',
-            offsetY: '2',
-            blur: '3',
-            spread: '4',
-            color: '#000',
-          },
-        }),
-      ).to.eql({ offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' });
-      expect(
-        transformDimension({
-          $type: 'shadow',
-          $value: {
-            offsetX: '1',
-            offsetY: '2',
-            blur: '3',
-            spread: '4',
-            color: '#000',
-          },
-        }),
-      ).to.eql({ offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' });
-    });
-
-    it('should add units to multi shadow props', () => {
-      expect(
-        transformDimension({
-          type: 'shadow',
-          value: [
-            {
+    describe('shadow', () => {
+      it('should add units to single shadow value props', () => {
+        expect(
+          transformDimension({
+            type: 'shadow',
+            value: {
               offsetX: '1',
-              offsetY: '2',
+              offsetY: 2,
               blur: '3',
               spread: '4',
               color: '#000',
             },
-          ],
-        }),
-      ).to.eql([{ offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' }]);
-      expect(
-        transformDimension({
-          $type: 'shadow',
-          $value: [
-            {
+          }),
+        ).to.eql({
+          offsetX: '1px',
+          offsetY: '2px',
+          blur: '3px',
+          spread: '4px',
+          color: '#000',
+        });
+        expect(
+          transformDimension({
+            type: 'shadow',
+            value: {
+              offsetX: '1 2',
+              offsetY: '3 4',
+              blur: '5 6',
+              spread: '7 8',
+              color: '#000',
+            },
+          }),
+        ).to.eql({
+          offsetX: '1px 2px',
+          offsetY: '3px 4px',
+          blur: '5px 6px',
+          spread: '7px 8px',
+          color: '#000',
+        });
+      });
+
+      it('should add units to shadow props with $type', () => {
+        expect(
+          transformDimension({
+            $type: 'shadow',
+            $value: {
               offsetX: '1',
-              offsetY: '2',
+              offsetY: 2,
               blur: '3',
               spread: '4',
               color: '#000',
             },
-          ],
-        }),
-      ).to.eql([{ offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' }]);
+          }),
+        ).to.eql({
+          offsetX: '1px',
+          offsetY: '2px',
+          blur: '3px',
+          spread: '4px',
+          color: '#000',
+        });
+        expect(
+          transformDimension({
+            $type: 'shadow',
+            $value: {
+              offsetX: '1 2',
+              offsetY: '3 4',
+              blur: '5 6',
+              spread: '7 8',
+              color: '#000',
+            },
+          }),
+        ).to.eql({
+          offsetX: '1px 2px',
+          offsetY: '3px 4px',
+          blur: '5px 6px',
+          spread: '7px 8px',
+          color: '#000',
+        });
+      });
+
+      it('should add units to multi-shadow props', () => {
+        expect(
+          transformDimension({
+            type: 'shadow',
+            value: [
+              {
+                offsetX: '1',
+                offsetY: '2',
+                blur: '3',
+                spread: '4',
+                color: '#000',
+              },
+              {
+                offsetX: '5',
+                offsetY: '6',
+                blur: '7',
+                spread: '8',
+                color: '#fff',
+              },
+            ],
+          }),
+        ).to.eql([
+          { offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' },
+          { offsetX: '5px', offsetY: '6px', blur: '7px', spread: '8px', color: '#fff' },
+        ]);
+
+        expect(
+          transformDimension({
+            type: 'shadow',
+            value: [
+              {
+                offsetX: '1 2',
+                offsetY: '3 4',
+                blur: '5 6',
+                spread: '7 8',
+                color: '#000',
+              },
+              {
+                offsetX: '5',
+                offsetY: '6',
+                blur: '7',
+                spread: '8',
+                color: '#fff',
+              },
+            ],
+          }),
+        ).to.eql([
+          {
+            offsetX: '1px 2px',
+            offsetY: '3px 4px',
+            blur: '5px 6px',
+            spread: '7px 8px',
+            color: '#000',
+          },
+          { offsetX: '5px', offsetY: '6px', blur: '7px', spread: '8px', color: '#fff' },
+        ]);
+
+        expect(
+          transformDimension({
+            $type: 'shadow',
+            $value: [
+              {
+                offsetX: '1',
+                offsetY: '2',
+                blur: '3',
+                spread: '4',
+                color: '#000',
+              },
+              {
+                offsetX: '5',
+                offsetY: '6',
+                blur: '7',
+                spread: '8',
+                color: '#fff',
+              },
+            ],
+          }),
+        ).to.eql([
+          { offsetX: '1px', offsetY: '2px', blur: '3px', spread: '4px', color: '#000' },
+          { offsetX: '5px', offsetY: '6px', blur: '7px', spread: '8px', color: '#fff' },
+        ]);
+      });
     });
 
-    it('should add units to border props', () => {
-      expect(
-        transformDimension({
-          type: 'border',
-          value: {
-            width: '4',
-            color: '#000',
-          },
-        }),
-      ).to.eql({ width: '4px', color: '#000' });
-      expect(
-        transformDimension({
-          $type: 'border',
-          $value: {
-            width: '4',
-            color: '#000',
-          },
-        }),
-      ).to.eql({ width: '4px', color: '#000' });
+    describe('border', () => {
+      it('should add units to border props', () => {
+        expect(
+          transformDimension({
+            type: 'border',
+            value: {
+              width: '4',
+              color: '#000',
+            },
+          }),
+        ).to.eql({ width: '4px', color: '#000' });
+        expect(
+          transformDimension({
+            type: 'border',
+            value: {
+              width: '4 8',
+              color: '#000',
+            },
+          }),
+        ).to.eql({ width: '4px 8px', color: '#000' });
+      });
+
+      it('should add units to border props with $type', () => {
+        expect(
+          transformDimension({
+            $type: 'border',
+            $value: {
+              width: '4',
+              color: '#000',
+            },
+          }),
+        ).to.eql({ width: '4px', color: '#000' });
+        expect(
+          transformDimension({
+            $type: 'border',
+            $value: {
+              width: '4 8',
+              color: '#000',
+            },
+          }),
+        ).to.eql({ width: '4px 8px', color: '#000' });
+      });
     });
   });
 });


### PR DESCRIPTION
sd-transforms now supports introducing multiple values for size tokens. If '8 16' is transmitted, it is transformed to '8px 16px'. Before, that was only happening when a single value was written.