### PR TITLE
fix: avoid checkAndEvaluateMatch returning NaN

### DIFF
--- a/.changeset/serious-islands-approve.md
+++ b/.changeset/serious-islands-approve.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/sd-transforms': patch
+---
+
+avoid checkAndEvaluateMath returning NaN

--- a/src/checkAndEvaluateMath.ts
+++ b/src/checkAndEvaluateMath.ts
@@ -135,7 +135,7 @@ function parseAndReduce(expr: string, fractionDigits = defaultFractionDigits): s
     // Attempt to reduce the math expression
     const reduced = reduceExpression(calcParsed);
     // E.g. if type is Length, like 4 * 7rem would be 28rem
-    if (reduced) {
+    if (reduced && !isNaN(reduced.value)) {
       result = reduced.value;
     }
   }

--- a/test/spec/checkAndEvaluateMath.spec.ts
+++ b/test/spec/checkAndEvaluateMath.spec.ts
@@ -272,4 +272,8 @@ describe('check and evaluate math', () => {
       ).to.eql(['0px 4px 12px #000000', '0px 8px 18px #0000008C']);
     });
   });
+
+  it('does not transform hex values containing E', () => {
+    expect(checkAndEvaluateMath({ value: 'E6', type: 'other' })).to.equal('E6');
+  });
 });


### PR DESCRIPTION
Fixes #336 