### PR TITLE
fix: 'tokens-studio' preprocessor 'add-font-styles' performance improvements for SD v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/sd-transforms",
-  "version": "1.2.12",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/sd-transforms",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
@@ -46,7 +46,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "style-dictionary": "^4.3.0 || ^5.0.0-rc.0"
+        "style-dictionary": "^5.0.0-rc.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1723,7 +1723,6 @@
       "version": "22.13.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
       "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -9455,15 +9454,16 @@
       }
     },
     "node_modules/style-dictionary": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.3.3.tgz",
-      "integrity": "sha512-93ISASYmvGdKOvNHFaOZ+mVsCNQdoZzhSEq7JINE0BjMoE8zUzkwFyGDUBnfmXayHq/F4B4MCWmtjqjgHAYthw==",
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.0.0-rc.2.tgz",
+      "integrity": "sha512-zHSYFm5wLjDxveSYAD3dSAAnj7ou8u6jze8MB1P9NEBpxo8mu7JXARXcZ7zmLDRZmoYoJnz179a1AiFITg1wHA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
         "@bundled-es-modules/memfs": "^4.9.4",
+        "@types/node": "^22.10.5",
         "@zip.js/zip.js": "^2.7.44",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
@@ -9479,7 +9479,7 @@
         "style-dictionary": "bin/style-dictionary.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/style-dictionary/node_modules/chalk": {
@@ -9975,8 +9975,7 @@
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/union": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "is-mergeable-object": "^1.1.1"
   },
   "peerDependencies": {
-    "style-dictionary": "^4.3.0 || ^5.0.0-rc.0"
+    "style-dictionary": "^5.0.0-rc.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.6",


### PR DESCRIPTION
This PR should improve the performance of the [add-font-styles](https://github.com/tokens-studio/sd-transforms/blob/main/src/preprocessors/add-font-styles.ts#L15) part of the `tokens-studio` preprocessor.

The foundation for this performance improvement is, that the preprocessors should also run on the flat `tokenMap` data of the tokens, which will be or has been introduced with [version 5.0.0 of Style-Dictionary](https://github.com/amzn/style-dictionary/pull/1498).

I am still not sure, if there might be updates needed in the preprocessor implementation on the Style-Dictionary side!? Therefore starting this PR, in order to clarify more on the details, on what has to be done.